### PR TITLE
PR: 추가 - 칸반보드 페이지 마크업

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -2,3 +2,11 @@ import '@babel/polyfill';
 
 // eslint-disable-next-line no-unused-vars
 import style from './stylesheets/style.css';
+
+import KanbanPage from './javascripts/Components/KanbanPage.js';
+
+const app = document.querySelector('#app');
+
+const kanbanPage = new KanbanPage().render();
+
+app.appendChild(kanbanPage);

--- a/src/index.html
+++ b/src/index.html
@@ -5,5 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Document</title>
   </head>
-  <body></body>
+  <body>
+    <div id="app"></div>
+  </body>
 </html>

--- a/src/javascripts/Components/Column.js
+++ b/src/javascripts/Components/Column.js
@@ -76,9 +76,31 @@ export default class Column extends Element {
     });
   }
 
+  pickNote(noteKey) {
+    const targetIndex = this.notes.findIndex((cur) => {
+      return cur.key === parseInt(noteKey);
+    });
+    if (targetIndex === -1) {
+      return;
+    }
+
+    const target = this.notes[targetIndex];
+    this.notes.splice(targetIndex, 1);
+    this.updateCount();
+
+    return target;
+  }
+
+  pushNote(note, index) {
+    this.notes.splice(index, 0, note);
+    this.updateCount();
+  }
+
   updateCount() {
     const count = this.element.querySelector('.count');
     count.innerText = this.notes.length;
+
+    console.log(this.notes);
   }
 
   setElement() {

--- a/src/javascripts/Components/Column.js
+++ b/src/javascripts/Components/Column.js
@@ -2,14 +2,16 @@ import Element from './Element.js';
 import Note from './Note.js';
 
 export default class Column extends Element {
-  constructor(column) {
+  constructor(data) {
     super();
 
     this.notes = [];
 
-    this.title = column.title;
-    column.notes.forEach((note) => {
+    this.key = data.key;
+    this.title = data.title;
+    data.notes.forEach((note) => {
       this.notes.push({
+        key: note.key,
         data: note,
         dom: new Note(note),
       });
@@ -20,6 +22,7 @@ export default class Column extends Element {
 
   getWrapper() {
     const wrapper = document.createElement('div');
+    wrapper.dataset.key = this.key;
     wrapper.className = 'column';
     return wrapper;
   }

--- a/src/javascripts/Components/Column.js
+++ b/src/javascripts/Components/Column.js
@@ -6,9 +6,11 @@ export default class Column extends Element {
     super();
 
     this.notes = [];
-
     this.key = data.key;
     this.title = data.title;
+    this.head = undefined;
+    this.ul = undefined;
+
     data.notes.forEach((note) => {
       this.notes.push({
         key: note.key,
@@ -56,24 +58,56 @@ export default class Column extends Element {
     head.appendChild(left_dom);
     head.appendChild(buttons);
 
+    this.addButton = plus_button;
+
+    this.head = head;
     return head;
   }
 
   getUl() {
     const ul = document.createElement('ul');
-
-    this.addLi(ul);
-
-    return ul;
-  }
-
-  addLi(ul) {
     const li = document.createElement('li');
     li.className = 'start_point';
     ul.appendChild(li);
+
     this.notes.forEach((note) => {
       ul.appendChild(note.dom.render());
     });
+
+    this.ul = ul;
+    return ul;
+  }
+
+  getCreateForm() {
+    const form = document.createElement('form');
+    form.classList.add('disable');
+    form.classList.add('hidden');
+
+    const textArea = document.createElement('textarea');
+    textArea.maxLength = 50;
+
+    const buttons = document.createElement('div');
+    buttons.className = 'buttons';
+    const createButton = document.createElement('button');
+    createButton.type = 'button';
+    createButton.className = 'create';
+    createButton.innerText = '생성';
+
+    const cancelButton = document.createElement('button');
+    cancelButton.type = 'button';
+    cancelButton.className = 'cancel';
+    cancelButton.innerText = '취소';
+
+    buttons.appendChild(createButton);
+    buttons.appendChild(cancelButton);
+
+    form.appendChild(textArea);
+    form.appendChild(buttons);
+
+    this.form = form;
+    this.textArea = textArea;
+    this.cancelButton = cancelButton;
+    return form;
   }
 
   pickNote(noteKey) {
@@ -107,8 +141,27 @@ export default class Column extends Element {
     const wrapper = this.getWrapper();
 
     wrapper.appendChild(this.getHeader());
+    wrapper.appendChild(this.getCreateForm());
     wrapper.appendChild(this.getUl());
 
     this.element = wrapper;
+  }
+
+  setEventListeners() {
+    this.addButton.addEventListener('click', () => {
+      this.form.classList.remove('hidden');
+    });
+    this.cancelButton.addEventListener('click', () => {
+      this.form.classList.add('hidden');
+    });
+    this.textArea.addEventListener('keydown', () => {
+      // console.log(this.textArea.value);
+      this.form.classList.remove('disable');
+    });
+    this.textArea.addEventListener('keyup', () => {
+      if (this.textArea.value.length < 1) {
+        this.form.classList.add('disable');
+      }
+    });
   }
 }

--- a/src/javascripts/Components/Column.js
+++ b/src/javascripts/Components/Column.js
@@ -1,0 +1,86 @@
+import Element from './Element.js';
+import Note from './Note.js';
+
+export default class Column extends Element {
+  constructor(column) {
+    super();
+
+    this.notes = [];
+
+    this.title = column.title;
+    column.notes.forEach((note) => {
+      this.notes.push({
+        data: note,
+        dom: new Note(note),
+      });
+    });
+
+    this.setElement();
+  }
+
+  getWrapper() {
+    const wrapper = document.createElement('div');
+    wrapper.className = 'column';
+    return wrapper;
+  }
+
+  getHeader() {
+    const head = document.createElement('div');
+    head.className = 'head';
+
+    const left_dom = document.createElement('div');
+    left_dom.className = 'left';
+    const count = document.createElement('div');
+    count.className = 'count';
+    count.innerText = this.notes.length;
+
+    const h1 = document.createElement('h1');
+    h1.innerText = this.title;
+
+    left_dom.appendChild(count);
+    left_dom.appendChild(h1);
+
+    const buttons = document.createElement('div');
+    buttons.className = 'buttons';
+    const plus_button = document.createElement('button');
+    plus_button.innerText = '+';
+    const more_button = document.createElement('button');
+    more_button.innerText = '...';
+
+    buttons.appendChild(plus_button);
+    buttons.appendChild(more_button);
+
+    head.appendChild(left_dom);
+    head.appendChild(buttons);
+
+    return head;
+  }
+
+  getUl() {
+    const ul = document.createElement('ul');
+
+    this.addLi(ul);
+
+    return ul;
+  }
+
+  addLi(ul) {
+    this.notes.forEach((note) => {
+      ul.appendChild(note.dom.render());
+    });
+  }
+
+  updateCount() {
+    const count = this.element.querySelector('.count');
+    count.innerText = this.notes.length;
+  }
+
+  setElement() {
+    const wrapper = this.getWrapper();
+
+    wrapper.appendChild(this.getHeader());
+    wrapper.appendChild(this.getUl());
+
+    this.element = wrapper;
+  }
+}

--- a/src/javascripts/Components/Column.js
+++ b/src/javascripts/Components/Column.js
@@ -65,6 +65,9 @@ export default class Column extends Element {
   }
 
   addLi(ul) {
+    const li = document.createElement('li');
+    li.className = 'start_point';
+    ul.appendChild(li);
     this.notes.forEach((note) => {
       ul.appendChild(note.dom.render());
     });

--- a/src/javascripts/Components/Column.js
+++ b/src/javascripts/Components/Column.js
@@ -106,6 +106,7 @@ export default class Column extends Element {
 
     this.form = form;
     this.textArea = textArea;
+    this.createButton = createButton;
     this.cancelButton = cancelButton;
     return form;
   }
@@ -137,6 +138,19 @@ export default class Column extends Element {
     console.log(this.notes);
   }
 
+  appendNote(data) {
+    const noteObject = {
+      key: data.key,
+      data: data,
+      dom: new Note(data),
+    };
+    this.pushNote(noteObject, 0);
+    this.ul.insertBefore(
+      noteObject.dom.render(),
+      this.ul.firstChild.nextSibling,
+    );
+  }
+
   setElement() {
     const wrapper = this.getWrapper();
 
@@ -162,6 +176,22 @@ export default class Column extends Element {
       if (this.textArea.value.length < 1) {
         this.form.classList.add('disable');
       }
+    });
+    this.createButton.addEventListener('click', () => {
+      if (this.form.classList.contains('disable')) {
+        return;
+      }
+
+      const noteObject = {
+        key: 123,
+        title: this.textArea.value,
+        name: 'ADMIN',
+      };
+
+      this.appendNote(noteObject);
+      this.textArea.value = null;
+      this.form.classList.add('disable');
+      this.form.classList.add('hidden');
     });
   }
 }

--- a/src/javascripts/Components/Element.js
+++ b/src/javascripts/Components/Element.js
@@ -1,0 +1,8 @@
+export default class Element {
+  render() {
+    if (this.setEventListeners) {
+      this.setEventListeners();
+    }
+    return this.element;
+  }
+}

--- a/src/javascripts/Components/Header.js
+++ b/src/javascripts/Components/Header.js
@@ -1,0 +1,43 @@
+import Element from './Element.js';
+
+export default class Header extends Element {
+  constructor() {
+    super();
+
+    this.setElement();
+  }
+
+  getWrapper() {
+    const wrapper = document.createElement('header');
+
+    return wrapper;
+  }
+
+  getMenu() {
+    const menu = document.createElement('div');
+    menu.className = 'menu';
+
+    const menu_button = document.createElement('button');
+    menu_button.innerText = 'menu';
+    menu.appendChild(menu_button);
+
+    return menu;
+  }
+
+  getLogo() {
+    const logo = document.createElement('div');
+    logo.className = 'logo';
+    logo.innerText = 'Todo List';
+
+    return logo;
+  }
+
+  setElement() {
+    const wrapper = this.getWrapper();
+
+    wrapper.appendChild(this.getLogo());
+    wrapper.appendChild(this.getMenu());
+
+    this.element = wrapper;
+  }
+}

--- a/src/javascripts/Components/Hover.js
+++ b/src/javascripts/Components/Hover.js
@@ -1,0 +1,43 @@
+import Element from './Element.js';
+
+export default class Hover extends Element {
+  constructor() {
+    super();
+    this.target = undefined;
+    this.setElement();
+  }
+
+  changeInnerDom(dom, x, y) {
+    this.target = dom;
+    this.element.appendChild(this.target);
+
+    this.element.style.left = x - this.element.offsetWidth / 2 + 'px';
+    this.element.style.top = y - this.element.offsetHeight / 2 + 'px';
+  }
+
+  clearInnerDom() {
+    if (this.target) {
+      this.element.removeChild(this.target);
+    }
+    this.target = undefined;
+  }
+
+  tracking(x, y) {
+    this.element.style.left = x - this.element.offsetWidth / 2 + 'px';
+    this.element.style.top = y - this.element.offsetHeight / 2 + 'px';
+  }
+
+  consoleLog() {
+    console.log('hello');
+  }
+
+  setElement() {
+    const hover = document.createElement('div');
+    hover.className = 'hover';
+    hover.style.position = 'absolute';
+    hover.style.zIndex = 1000;
+    hover.style.width = 400 + 'px';
+
+    this.element = hover;
+  }
+}

--- a/src/javascripts/Components/Kanban.js
+++ b/src/javascripts/Components/Kanban.js
@@ -122,9 +122,21 @@ export default class Kanban extends Element {
     hover.clearInnerDom();
   }
 
+  _mouseleave() {
+    if (!this.clicked) {
+      return;
+    }
+    if (this.li) {
+      this.li.classList.remove('temp_space');
+      this.li = undefined;
+    }
+    hover.clearInnerDom();
+  }
+
   setEventListeners() {
     this.element.addEventListener('mousemove', this._mousemove);
     this.element.addEventListener('mousedown', this._mousedown);
     this.element.addEventListener('mouseup', this._mouseup);
+    this.element.addEventListener('mouseleave', this._mouseleave);
   }
 }

--- a/src/javascripts/Components/Kanban.js
+++ b/src/javascripts/Components/Kanban.js
@@ -1,5 +1,18 @@
 import Element from './Element.js';
 import Column from './Column.js';
+import Hover from './Hover.js';
+
+function isBefore(element1, element2) {
+  let cur;
+  if (element2.parentNode === element1.parentNode) {
+    for (cur = element1.previousSibling; cur; cur = cur.previousSibling) {
+      if (cur === element2) return true;
+    }
+  }
+  return false;
+}
+
+let hover = undefined;
 
 export default class Kanban extends Element {
   constructor(kanban) {
@@ -12,6 +25,9 @@ export default class Kanban extends Element {
         dom: new Column(column),
       });
     });
+
+    this.hover = new Hover();
+    hover = this.hover;
 
     this.setElement();
   }
@@ -33,11 +49,61 @@ export default class Kanban extends Element {
   setElement() {
     const wrapper = this.getWrapper();
     this.addColumn(wrapper);
+    wrapper.appendChild(this.hover.render());
 
     this.element = wrapper;
   }
 
+  _trackCurser(event) {
+    if (!this.clicked) return;
+
+    // pageX, pageY 는 모든 페이지 기반
+    // clientX, clientY 는 현제 보이는 화면 기반
+    const { pageX, pageY } = event;
+    hover.element.hidden = true;
+    const elemBelow = document.elementFromPoint(pageX, pageY);
+    const li = elemBelow.closest('li');
+    hover.element.hidden = false;
+
+    hover.tracking(pageX, pageY);
+
+    if (li === null || this.li === undefined) {
+      return;
+    }
+
+    const { className } = li;
+
+    if (isBefore(this.li, li) && className !== 'start_point') {
+      li.parentNode.insertBefore(this.li, li);
+    } else {
+      li.parentNode.insertBefore(this.li, li.nextSibling);
+    }
+  }
+
+  _mousedown(event) {
+    this.clicked = true;
+    const target = event.target.closest('li');
+
+    if (target.className === 'start_point') {
+      return;
+    }
+
+    this.li = target.cloneNode(true);
+    this.li.classList.add('temp_space');
+    hover.changeInnerDom(target.cloneNode(true), event.pageX, event.pageY);
+    target.remove();
+  }
+
+  _mouseup() {
+    this.clicked = false;
+    this.li.classList.remove('temp_space');
+    this.li = undefined;
+    hover.clearInnerDom();
+  }
+
   setEventListeners() {
-    // this.element.addEventListener();
+    this.element.addEventListener('mousemove', this._trackCurser, false);
+    this.element.addEventListener('mousedown', this._mousedown);
+    this.element.addEventListener('mouseup', this._mouseup);
   }
 }

--- a/src/javascripts/Components/Kanban.js
+++ b/src/javascripts/Components/Kanban.js
@@ -122,7 +122,7 @@ export default class Kanban extends Element {
 
   _mouseup() {
     this.clicked = false;
-    if (this.li) {
+    if (this.li && this.li.closest('.column')) {
       this.li.classList.remove('temp_space');
 
       const { key } = this.li.closest('.column').dataset;

--- a/src/javascripts/Components/Kanban.js
+++ b/src/javascripts/Components/Kanban.js
@@ -15,15 +15,21 @@ function isBefore(element1, element2) {
 let hover = undefined;
 
 export default class Kanban extends Element {
-  constructor(kanban) {
+  constructor(data) {
     super();
 
+    this.key = data.key;
     this.columns = [];
-    kanban.columns.forEach((column) => {
-      this.columns.push({
+    this.columnsMap = new Map();
+
+    data.columns.forEach((column) => {
+      const columnObject = {
+        key: column.key,
         data: column,
         dom: new Column(column),
-      });
+      };
+      this.columns.push(columnObject);
+      this.columnsMap.set(column.key, columnObject);
     });
 
     this.hover = new Hover();
@@ -37,6 +43,7 @@ export default class Kanban extends Element {
     const wrapper = document.createElement('div');
     wrapper.className = 'kanban';
     wrapper.id = 'mytodo';
+    wrapper.dataset.key = this.key;
 
     return wrapper;
   }

--- a/src/javascripts/Components/Kanban.js
+++ b/src/javascripts/Components/Kanban.js
@@ -14,6 +14,8 @@ function isBefore(element1, element2) {
 
 let hover = undefined;
 let targetRemove = undefined;
+let targetData = undefined;
+let columnsMap = new Map();
 
 export default class Kanban extends Element {
   constructor(data) {
@@ -21,7 +23,6 @@ export default class Kanban extends Element {
 
     this.key = data.key;
     this.columns = [];
-    this.columnsMap = new Map();
 
     data.columns.forEach((column) => {
       const columnObject = {
@@ -30,11 +31,12 @@ export default class Kanban extends Element {
         dom: new Column(column),
       };
       this.columns.push(columnObject);
-      this.columnsMap.set(column.key, columnObject);
+      columnsMap.set(column.key, columnObject);
     });
 
     this.hover = new Hover();
     this.li = undefined;
+
     hover = this.hover;
 
     this.setElement();
@@ -90,6 +92,11 @@ export default class Kanban extends Element {
 
     // delete hover target
     if (targetRemove) {
+      const { key } = targetRemove.closest('.column').dataset;
+      const columnObject = columnsMap.get(parseInt(key)).dom;
+
+      targetData = columnObject.pickNote(targetRemove.dataset.key);
+
       targetRemove.remove();
       targetRemove = undefined;
     }
@@ -117,6 +124,21 @@ export default class Kanban extends Element {
     this.clicked = false;
     if (this.li) {
       this.li.classList.remove('temp_space');
+
+      const { key } = this.li.closest('.column').dataset;
+      const columnObject = columnsMap.get(parseInt(key)).dom;
+      const ul = columnObject.element.querySelector('ul');
+
+      let index = -1;
+      Array.from(ul.children).forEach((cur, idx) => {
+        if (parseInt(cur.dataset.key) === targetData.key) {
+          index = idx;
+        }
+      });
+
+      columnObject.pushNote(targetData, index - 1);
+
+      targetData = undefined;
       this.li = undefined;
     }
     hover.clearInnerDom();
@@ -128,6 +150,21 @@ export default class Kanban extends Element {
     }
     if (this.li) {
       this.li.classList.remove('temp_space');
+
+      const { key } = this.li.closest('.column').dataset;
+      const columnObject = columnsMap.get(parseInt(key)).dom;
+      const ul = columnObject.element.querySelector('ul');
+
+      let index = -1;
+      Array.from(ul.children).forEach((cur, idx) => {
+        if (parseInt(cur.dataset.key) === targetData.key) {
+          index = idx;
+        }
+      });
+
+      columnObject.pushNote(targetData, index - 1);
+
+      targetData = undefined;
       this.li = undefined;
     }
     hover.clearInnerDom();

--- a/src/javascripts/Components/Kanban.js
+++ b/src/javascripts/Components/Kanban.js
@@ -27,6 +27,7 @@ export default class Kanban extends Element {
     });
 
     this.hover = new Hover();
+    this.li = undefined;
     hover = this.hover;
 
     this.setElement();
@@ -83,7 +84,9 @@ export default class Kanban extends Element {
   _mousedown(event) {
     this.clicked = true;
     const target = event.target.closest('li');
-
+    if (!target) {
+      return;
+    }
     if (target.className === 'start_point') {
       return;
     }
@@ -96,8 +99,10 @@ export default class Kanban extends Element {
 
   _mouseup() {
     this.clicked = false;
-    this.li.classList.remove('temp_space');
-    this.li = undefined;
+    if (this.li) {
+      this.li.classList.remove('temp_space');
+      this.li = undefined;
+    }
     hover.clearInnerDom();
   }
 

--- a/src/javascripts/Components/Kanban.js
+++ b/src/javascripts/Components/Kanban.js
@@ -1,0 +1,43 @@
+import Element from './Element.js';
+import Column from './Column.js';
+
+export default class Kanban extends Element {
+  constructor(kanban) {
+    super();
+
+    this.columns = [];
+    kanban.columns.forEach((column) => {
+      this.columns.push({
+        data: column,
+        dom: new Column(column),
+      });
+    });
+
+    this.setElement();
+  }
+
+  getWrapper() {
+    const wrapper = document.createElement('div');
+    wrapper.className = 'kanban';
+    wrapper.id = 'mytodo';
+
+    return wrapper;
+  }
+
+  addColumn(wrapper) {
+    this.columns.forEach((column) => {
+      wrapper.appendChild(column.dom.render());
+    });
+  }
+
+  setElement() {
+    const wrapper = this.getWrapper();
+    this.addColumn(wrapper);
+
+    this.element = wrapper;
+  }
+
+  setEventListeners() {
+    // this.element.addEventListener();
+  }
+}

--- a/src/javascripts/Components/KanbanPage.js
+++ b/src/javascripts/Components/KanbanPage.js
@@ -6,37 +6,46 @@ import Kanban from './Kanban.js';
 import kanban from '../../stylesheets/kanban.css';
 
 const data = {
+  key: '1',
   columns: [
     {
+      key: 1,
       title: 'Todo',
       notes: [
         {
+          key: 1,
           title: '첫번쨰 할일',
           name: 'crong',
         },
         {
+          key: 2,
           title: '두번쨰 할일',
           name: 'pobi',
         },
       ],
     },
     {
+      key: 2,
       title: 'Doing',
       notes: [
         {
+          key: 3,
           title: '세번쨰 할일',
           name: 'woowa',
         },
         {
+          key: 4,
           title: '네번쨰 할일',
           name: 'boost',
         },
       ],
     },
     {
+      key: 3,
       title: 'Done',
       notes: [
         {
+          key: 5,
           title: '다섯번쨰 할일',
           name: 'superman',
         },

--- a/src/javascripts/Components/KanbanPage.js
+++ b/src/javascripts/Components/KanbanPage.js
@@ -48,9 +48,10 @@ const data = {
 export default class KanbanPage extends Element {
   constructor() {
     super();
+    this.header = new Header();
+    this.kanban = null;
 
     this.setElement();
-    this.fetchKanbanData();
   }
 
   fetchKanbanData() {
@@ -63,10 +64,8 @@ export default class KanbanPage extends Element {
   setElement() {
     const wrapper = document.createElement('div');
 
-    this.header = new Header().render();
-    this.kanban = null;
-
-    wrapper.appendChild(this.header);
+    wrapper.appendChild(this.header.render());
+    this.fetchKanbanData();
 
     this.element = wrapper;
   }

--- a/src/javascripts/Components/KanbanPage.js
+++ b/src/javascripts/Components/KanbanPage.js
@@ -1,0 +1,73 @@
+import Element from './Element.js';
+import Header from './Header.js';
+import Kanban from './Kanban.js';
+
+// eslint-disable-next-line no-unused-vars
+import kanban from '../../stylesheets/kanban.css';
+
+const data = {
+  columns: [
+    {
+      title: 'Todo',
+      notes: [
+        {
+          title: '첫번쨰 할일',
+          name: 'crong',
+        },
+        {
+          title: '두번쨰 할일',
+          name: 'pobi',
+        },
+      ],
+    },
+    {
+      title: 'Doing',
+      notes: [
+        {
+          title: '세번쨰 할일',
+          name: 'woowa',
+        },
+        {
+          title: '네번쨰 할일',
+          name: 'boost',
+        },
+      ],
+    },
+    {
+      title: 'Done',
+      notes: [
+        {
+          title: '다섯번쨰 할일',
+          name: 'superman',
+        },
+      ],
+    },
+  ],
+};
+
+export default class KanbanPage extends Element {
+  constructor() {
+    super();
+
+    this.setElement();
+    this.fetchKanbanData();
+  }
+
+  fetchKanbanData() {
+    setTimeout(() => {
+      this.kanban = new Kanban(data).render();
+      this.element.appendChild(this.kanban);
+    }, 0);
+  }
+
+  setElement() {
+    const wrapper = document.createElement('div');
+
+    this.header = new Header().render();
+    this.kanban = null;
+
+    wrapper.appendChild(this.header);
+
+    this.element = wrapper;
+  }
+}

--- a/src/javascripts/Components/Note.js
+++ b/src/javascripts/Components/Note.js
@@ -1,17 +1,19 @@
 import Element from './Element.js';
 
 export default class Note extends Element {
-  constructor(note) {
+  constructor(data) {
     super();
 
-    this.title = note.title;
-    this.name = note.name;
+    this.key = data.key;
+    this.title = data.title;
+    this.name = data.name;
 
     this.setElement();
   }
 
   getWrapper() {
     const li = document.createElement('li');
+    li.dataset.key = this.key;
 
     return li;
   }

--- a/src/javascripts/Components/Note.js
+++ b/src/javascripts/Components/Note.js
@@ -1,0 +1,60 @@
+import Element from './Element.js';
+
+export default class Note extends Element {
+  constructor(note) {
+    super();
+
+    this.title = note.title;
+    this.name = note.name;
+
+    this.setElement();
+  }
+
+  getWrapper() {
+    const li = document.createElement('li');
+
+    return li;
+  }
+
+  getFooter() {
+    const footer = document.createElement('footer');
+
+    const p = document.createElement('p');
+    p.className = 'comment';
+    p.innerText = 'Add by';
+    const p_writter = document.createElement('p');
+    p_writter.className = 'writter';
+    p_writter.innerText = `${this.name}`;
+    footer.appendChild(p);
+    footer.appendChild(p_writter);
+
+    return footer;
+  }
+
+  getSection() {
+    const section = document.createElement('section');
+    section.className = 'content';
+    section.innerText = `${this.title}`;
+
+    return section;
+  }
+
+  setElement() {
+    const wrapper = this.getWrapper();
+
+    const button = document.createElement('button');
+    button.className = 'close';
+    button.innerText = 'X';
+
+    const section = this.getSection();
+    const hr = document.createElement('hr');
+    const footer = this.getFooter(name);
+
+    wrapper.appendChild(button);
+    wrapper.appendChild(section);
+    wrapper.appendChild(hr);
+    wrapper.appendChild(footer);
+
+    this.element = wrapper;
+  }
+}

--- a/src/stylesheets/kanban.css
+++ b/src/stylesheets/kanban.css
@@ -1,0 +1,221 @@
+body {
+  margin: 0;
+}
+
+body header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+
+  height: 50px;
+
+  background-color: #333333;
+}
+
+body header .logo {
+  margin: 0 10px 0 0;
+  padding: 5px;
+  color: #ffffff;
+}
+
+body header .menu {
+  margin: 0 10px 0 0;
+}
+
+body header .menu button {
+  border: none;
+  outline: none;
+  background-color: transparent;
+  padding: 5px;
+  font-size: 1.5rem;
+}
+
+body header .menu button:hover {
+  color: #ffffff;
+}
+
+.dragging {
+  opacity: 1;
+
+  transform: rotate(30);
+
+  border: 1px solid black;
+  background-color: skyblue;
+}
+
+body section {
+  margin-top: 10px;
+}
+
+.kanban {
+  display: flex;
+  flex-direction: row;
+
+  overflow-x: auto;
+}
+
+.kanban .column {
+  width: 400px;
+  margin: 0 20px 0 20px;
+  border: 1px solid #000000;
+  padding: 5px;
+  border-radius: 10px;
+
+  background-color: #cccccc;
+}
+
+.kanban .column .head {
+  width: inherit;
+  height: 30px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.kanban .column .head .left {
+  display: flex;
+  justify-content: start;
+  align-items: center;
+}
+
+.kanban .column .head .left .count {
+  width: 1.5rem;
+  height: 1.5rem;
+  line-height: 1.5rem;
+  border-radius: 1.5rem;
+  color: #ffffff;
+  background-color: #444444;
+
+  text-align: center;
+
+  font-size: 0.8rem;
+}
+
+.kanban .column .head .left h1 {
+  margin: 0 0 0 5px;
+  font-size: 1rem;
+}
+
+.kanban .column .head div.buttons {
+  margin-right: 5px;
+}
+
+.kanban .column .head div.buttons button {
+  width: 20px;
+  height: 20px;
+  padding: 0px;
+}
+
+.kanban .column ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.kanban .column ul li {
+  /* block drag */
+  user-select: none;
+
+  margin: 10px;
+  padding: 5px;
+  border-radius: 10px;
+  border: 1px solid #000000;
+  position: relative;
+  word-break: break-all;
+
+  background-color: #ffffff;
+}
+
+.kanban .column ul li.standard {
+  width: inherit;
+  height: inherit;
+}
+
+.kanban .column ul li button.close {
+  width: 20px;
+  height: 20px;
+  padding: 0px;
+  position: absolute;
+  top: 10px;
+  right: 10px;
+}
+
+.kanban .column ul li section.content {
+  margin: 10px 30px 10px 10px;
+}
+
+.kanban .column footer {
+  margin: 5px;
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+}
+
+.kanban .column footer p {
+  margin: 2px;
+}
+
+.kanban .column footer p.comment {
+  margin-left: 2px;
+  color: #444444;
+  font-style: italic;
+}
+
+.kanban .column footer p.writter {
+  color: #000000;
+}
+
+.hover {
+  position: absolute;
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  width: 400px;
+}
+
+.hover li {
+  /* block drag */
+  user-select: none;
+
+  margin: 10px;
+  padding: 5px;
+  border-radius: 10px;
+  border: 1px solid #000000;
+  position: relative;
+  word-break: break-all;
+
+  background-color: #ffffff;
+}
+
+.hover li.standard {
+  height: inherit;
+}
+
+.hover li button.close {
+  width: 20px;
+  height: 20px;
+  padding: 0px;
+  position: absolute;
+  top: 10px;
+  right: 10px;
+}
+
+.hover li section.content {
+  margin: 10px 30px 10px 10px;
+}
+
+.hover li footer {
+  margin: 5px;
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+}
+
+.hover li footer p {
+  margin: 2px;
+  color: #444444;
+}
+
+.hover li footer p.writter {
+  color: #000000;
+}

--- a/src/stylesheets/kanban.css
+++ b/src/stylesheets/kanban.css
@@ -135,6 +135,10 @@ body section {
   background-color: #ffffff;
 }
 
+.kanban .column ul li.temp_space {
+  opacity: 0.5;
+}
+
 .kanban .column ul li button.close {
   width: 20px;
   height: 20px;

--- a/src/stylesheets/kanban.css
+++ b/src/stylesheets/kanban.css
@@ -1,5 +1,7 @@
 body {
   margin: 0;
+
+  overflow-x: hidden;
 }
 
 body header {
@@ -52,11 +54,13 @@ body section {
   flex-direction: row;
 
   overflow-x: auto;
+
+  height: calc(100vh - 56px);
 }
 
 .kanban .column {
   width: 400px;
-  margin: 0 20px 0 20px;
+  margin: 10px;
   border: 1px solid #000000;
   padding: 5px;
   border-radius: 10px;
@@ -110,11 +114,16 @@ body section {
   list-style: none;
   padding: 0;
   margin: 0;
+
+  overflow-y: auto;
 }
 
 .kanban .column ul li {
   /* block drag */
   user-select: none;
+
+  width: inherit;
+  height: inherit;
 
   margin: 10px;
   padding: 5px;
@@ -124,11 +133,6 @@ body section {
   word-break: break-all;
 
   background-color: #ffffff;
-}
-
-.kanban .column ul li.standard {
-  width: inherit;
-  height: inherit;
 }
 
 .kanban .column ul li button.close {
@@ -170,7 +174,8 @@ body section {
   list-style: none;
   padding: 0;
   margin: 0;
-  width: 400px;
+
+  transform: rotate(-5deg);
 }
 
 .hover li {

--- a/src/stylesheets/kanban.css
+++ b/src/stylesheets/kanban.css
@@ -228,3 +228,97 @@ body section {
 .hover li footer p.writter {
   color: #000000;
 }
+
+/* 칸반 > 칼럼 > 새로운 노트 생성 */
+
+.kanban .column form {
+  margin: 10px 10px 0 10px;
+  border: 1px solid #000000;
+  padding: 5px;
+  border-radius: 10px;
+
+  background-color: #ffffff;
+}
+
+.kanban .column form.hidden {
+  display: none;
+}
+
+.kanban .column form textarea {
+  width: calc(100% - 6px);
+  height: 40px;
+  resize: vertical;
+}
+
+.kanban .column form div.buttons {
+  width: 100%;
+
+  display: flex;
+  justify-content: space-between;
+}
+
+.kanban .column form div.buttons button {
+  width: calc(50% - 10px);
+  height: 30px;
+  padding: 0px;
+  margin: 5px;
+  border: solid 1px #000000;
+
+  border-radius: 7px;
+
+  transition: all 0.2s ease;
+}
+
+.kanban .column form div.buttons button:active {
+  outline: none;
+}
+
+.kanban .column form div.buttons button:focus {
+  outline: 0;
+}
+
+.kanban .column form div.buttons button.create {
+  background-color: #2ea44f;
+  color: #ffffff;
+}
+
+.kanban .column form div.buttons button.create:hover {
+  background-color: #2c8f48;
+}
+
+.kanban .column form div.buttons button.create:active {
+  background-color: #298643;
+}
+
+.kanban .column form.disable div.buttons button.create {
+  background-color: #307c46;
+  color: #dddddd;
+}
+
+.kanban .column form.disable div.buttons button.create:hover {
+  background-color: #307c46;
+}
+
+.kanban .column form.disable div.buttons button.create:active {
+  background-color: #307c46;
+}
+
+.kanban .column form div.buttons button.cancel {
+  background-color: #eeeeee;
+  color: #000000;
+}
+
+.kanban .column form div.buttons button.cancel:hover {
+  background-color: #dddddd;
+}
+
+.kanban .column form div.buttons button.cancel:active {
+  background-color: #cccccc;
+}
+
+.kanban .column form div.disable {
+  width: 100%;
+
+  display: flex;
+  justify-content: space-between;
+}

--- a/src/stylesheets/style.css
+++ b/src/stylesheets/style.css
@@ -1,9 +1,0 @@
-body {
-  padding: 50px;
-  font: 14px 'Lucida Grande', Helvetica, Arial, sans-serif;
-  background: #cdcdcd;
-}
-
-a {
-  color: #00b7ff;
-}


### PR DESCRIPTION
> 칸반 페이지 렌더링 및 노트 드래그 기능 추가

## related issue

- #3 
- #13 
- #16 

## 설명 (what, why)

SPA 내부 컴포넌트 구현을 위해, 컴포넌트를 class형으로 선언해 사용
내부 dom을 rendering 하고 싶은 경우 render() 메소드를 호출하면 dom element를 return함

노트 드래그의 경우 drag&drop api를 사용한 것이 아닌 mouse event로 처리함

드래그 시 예외상황 처리 (에러)
- 마우스가 화면을 벗어 났을 때 : 드래그가 끝났을 떄와 같게 동작함

노트 드래그시 연관된 column의 내부 Array의 정보 수정
Array의 정보 수정시 왼쪽 상단 count도 변경
