### PR TITLE
PR: 추가 - 유저 액세스 토큰 API

### DIFF
--- a/apis/constants/config.js
+++ b/apis/constants/config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  COOKIE_MAX_AGE: require('../../dao/constants/config').TOKEN_AGE_SECONDS,
+  COOKIE_NAME: 'token_id',
+};

--- a/apis/constants/message.js
+++ b/apis/constants/message.js
@@ -1,0 +1,18 @@
+module.exports = {
+  LOGIN_PARAMETER_ERROR: {
+    TEXT: '올바르지 않은 전송입니다.',
+    STATUS_CODE: 400,
+  },
+  LOGIN_CANNOT_FOUND_USER: {
+    TEXT: '존재하지 않는 유저입니다.',
+    STATUS_CODE: 404,
+  },
+  LOGIN_SUCCESS: {
+    TEXT: '성공적으로 로그인되었습니다.',
+    STATUS_CODE: 200,
+  },
+  LOGIN_MYSQL_ERROR: {
+    TEXT: '알 수 없는 오류가 발생했습니다.',
+    STATUS_CODE: 503,
+  },
+};

--- a/apis/index.js
+++ b/apis/index.js
@@ -1,0 +1,8 @@
+const express = require('express');
+const loginRouter = require('./login');
+
+const router = express.Router();
+
+router.use(loginRouter);
+
+module.exports = router;

--- a/apis/login.js
+++ b/apis/login.js
@@ -1,0 +1,62 @@
+const express = require('express');
+const dao = require('../dao/dao.js');
+const { body, matchedData, validationResult } = require('express-validator');
+const safePromise = require('../utils/safePromise');
+const MESSAGE = require('./constants/message');
+const CONFIG = require('./constants/config');
+
+const router = express.Router();
+
+router.post(
+  '/login',
+  [body('userId').isInt({ min: 1 }).trim()],
+  async (req, res, next) => {
+    const result = {
+      success: false,
+      message: '',
+    };
+
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      result.message = MESSAGE.LOGIN_PARAMETER_ERROR.TEXT;
+      result.description = errors.errors;
+      res.status(MESSAGE.LOGIN_PARAMETER_ERROR.STATUS_CODE).json(result);
+      return;
+    }
+
+    const matchedBody = matchedData(req);
+    const [user, userError] = await safePromise(
+      dao.getUserById(matchedBody.userId),
+    );
+
+    if (userError) {
+      result.message = MESSAGE.LOGIN_MYSQL_ERROR.TEXT;
+      res.status(MESSAGE.LOGIN_MYSQL_ERROR.STATUS_CODE).json(result);
+      return;
+    }
+
+    if (!user.id) {
+      result.message = MESSAGE.LOGIN_CANNOT_FOUND_USER.TEXT;
+      res.status(MESSAGE.LOGIN_CANNOT_FOUND_USER.STATUS_CODE).json(result);
+      return;
+    }
+
+    const [token, tokenError] = await safePromise(dao.createUserToken(user.id));
+
+    if (tokenError) {
+      result.message = MESSAGE.LOGIN_MYSQL_ERROR.TEXT;
+      res.status(MESSAGE.LOGIN_MYSQL_ERROR.STATUS_CODE).json(result);
+      return;
+    }
+
+    result.success = true;
+    result.message = MESSAGE.LOGIN_SUCCESS.TEXT;
+
+    res.cookie(CONFIG.COOKIE_NAME, token, {
+      maxAge: CONFIG.COOKIE_MAX_AGE,
+    });
+    res.status(MESSAGE.LOGIN_SUCCESS.STATUS_CODE).json(result);
+  },
+);
+
+module.exports = router;

--- a/apis/users.js
+++ b/apis/users.js
@@ -1,9 +1,0 @@
-var express = require('express');
-var router = express.Router();
-
-/* GET users listing. */
-router.get('/', function (req, res, next) {
-  res.send('respond with a resource');
-});
-
-module.exports = router;

--- a/app.js
+++ b/app.js
@@ -5,7 +5,7 @@ const path = require('path');
 const cookieParser = require('cookie-parser');
 const logger = require('morgan');
 
-const usersRouter = require('./apis/users');
+const apiRouters = require('./apis/');
 
 const app = express();
 
@@ -19,7 +19,7 @@ app.use(express.json());
 app.use(express.urlencoded({ extended: false }));
 app.use(cookieParser());
 
-app.use('/api', usersRouter);
+app.use('/api', apiRouters);
 
 app.use(express.static(path.join(__dirname, 'dist')));
 

--- a/dao/DataAccessObject.js
+++ b/dao/DataAccessObject.js
@@ -1,7 +1,11 @@
 const mysql = require('mysql2');
+const crypto = require('crypto');
+const CONFIG = require('./constants/config');
 const TABLE = require('./constants/table');
 const User = require('./dto/User');
+const UserToken = require('./dto/UserToken');
 const safePromise = require('../utils/safePromise');
+const dt = require('../utils/datetime');
 
 class DataAccessObject {
   constructor(option) {
@@ -66,6 +70,61 @@ class DataAccessObject {
 
     connection.release();
     return new User(rows[0]);
+  }
+
+  async createUserToken(userId) {
+    const [connection, connectionError] = await safePromise(
+      this.getConnection(),
+    );
+    if (connectionError) {
+      throw connectionError;
+    }
+
+    const token = crypto
+      .createHash('sha256')
+      .update(`${dt.getCurrentWithFormat()}/${userId}`)
+      .digest('hex');
+
+    const expiredAt = dt.getFormatWithAdd(CONFIG.TOKEN_AGE_SECONDS);
+
+    const [_, insertError] = await safePromise(
+      this.executeQuery(
+        connection,
+        `INSERT INTO ${TABLE.USER_TOKEN} (id, user_id, token, expired_at) VALUES (null, ?, ?, ?)`,
+        [userId, token, expiredAt],
+      ),
+    );
+
+    if (insertError) {
+      throw insertError;
+    }
+
+    connection.release();
+    return true;
+  }
+
+  async getTokenInfo(token) {
+    const [connection, connectionError] = await safePromise(
+      this.getConnection(),
+    );
+    if (connectionError) {
+      throw connectionError;
+    }
+
+    const [rows, rowsError] = await safePromise(
+      this.executeQuery(
+        connection,
+        `SELECT * FROM ${TABLE.USER_TOKEN} WHERE token = ?`,
+        [token],
+      ),
+    );
+
+    if (rowsError) {
+      throw rowsError;
+    }
+
+    connection.release();
+    return new UserToken(rows[0]);
   }
 }
 

--- a/dao/constants/config.js
+++ b/dao/constants/config.js
@@ -1,0 +1,5 @@
+const hour = 3600;
+
+module.exports = {
+  TOKEN_AGE_SECONDS: 24 * hour,
+};

--- a/dao/constants/poolOptions.js
+++ b/dao/constants/poolOptions.js
@@ -8,6 +8,7 @@ module.exports = {
     password: process.env.DB_TEST_PASSWORD,
     database: process.env.DB_TEST_NAME,
     connectionLimit: 30,
+    charset: 'utf8mb4',
   },
   production: {
     host: process.env.DB_HOST,
@@ -16,5 +17,6 @@ module.exports = {
     password: process.env.DB_PASSWORD,
     database: process.env.DB_NAME,
     connectionLimit: 30,
+    charset: 'utf8mb4',
   },
 };

--- a/dao/dao.js
+++ b/dao/dao.js
@@ -1,4 +1,4 @@
 const DataAccessObject = require('./DataAccessObject');
-const pool = require('./poolOptions').production;
+const pool = require('./constants/poolOptions').production;
 
 module.exports = new DataAccessObject(pool);

--- a/dao/dto/User.js
+++ b/dao/dto/User.js
@@ -1,8 +1,8 @@
 class User {
   constructor(attrs) {
-    this.id = attrs.id;
-    this.name = attrs.name;
-    this.profile_image = attrs.profile_image;
+    this.id = attrs?.id;
+    this.name = attrs?.name;
+    this.profile_image = attrs?.profile_image;
   }
 }
 

--- a/dao/dto/UserToken.js
+++ b/dao/dto/UserToken.js
@@ -1,0 +1,10 @@
+class UserToken {
+  constructor(attrs) {
+    this.id = attrs?.id;
+    this.userId = attrs?.userId;
+    this.token = attrs?.token;
+    this.expiredAt = attrs?.expiredAt;
+  }
+}
+
+module.exports = UserToken;

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "dotenv": "^8.2.0",
     "ejs": "^3.1.3",
     "express": "~4.16.1",
+    "express-validator": "^6.6.0",
     "http-errors": "~1.6.3",
     "morgan": "~1.9.1",
     "mysql2": "^2.1.0"


### PR DESCRIPTION
> DAO에 유저 토큰 발급하는 함수 추가,  이외 API에 필요한 전반적인 작업 진행함.

## related issue

- #23 

## 설명 (what, why)
### 1. 토큰 API에서 호출할 DAO 관련 함수 추가
### 2. API 라우터를 분리
- 앞으로 apis/index.js가 API에 대한 라우팅을 일괄 처리
- API 라우팅에 대한 정보는 일괄 확인할 수 있음
### 3. API Response에 대한 값 분리
- 앞으로 API에서 보내는 상태 코드, 메세지는 이 곳에서 통합 관리하여, 유지보수를 고려.
