### PR TITLE
PR: 추가 - 액티비티 로그

### DIFF
--- a/src/javascripts/Components/ActivityLog.js
+++ b/src/javascripts/Components/ActivityLog.js
@@ -10,6 +10,7 @@ const mockData = {
   method: 'moved',
   columnFrom: 'Todo',
   columnTo: 'Done',
+  time: '1 min ago',
 };
 
 const mockDatas = [];

--- a/src/javascripts/Components/ActivityLog.js
+++ b/src/javascripts/Components/ActivityLog.js
@@ -1,0 +1,123 @@
+import Element from './Element.js';
+import Log from './Log.js';
+
+// eslint-disable-next-line no-unused-vars
+import style from '../../stylesheets/activityLog.css';
+
+const mockData = {
+  data: '@hello',
+  noteTitle: '집에가기',
+  method: 'moved',
+  columnFrom: 'Todo',
+  columnTo: 'Done',
+};
+
+const mockDatas = [];
+
+for (let i = 0; i < 10; i++) {
+  mockDatas.push(mockData);
+}
+
+export default class ActivityLog extends Element {
+  constructor() {
+    super();
+
+    this.logs = [];
+
+    this.wrapper = undefined;
+    this.closeButton = undefined;
+    this.ul = undefined;
+    this.moreButton = undefined;
+    this.setElement();
+  }
+
+  getWrapper() {
+    const wrapper = document.createElement('div');
+    wrapper.id = 'activity_log';
+    wrapper.className = 'close';
+
+    this.wrapper = wrapper;
+    return wrapper;
+  }
+
+  getHead() {
+    const head = document.createElement('div');
+    head.className = 'head';
+
+    const componentName = document.createElement('div');
+    componentName.innerText = 'menu';
+
+    const closeButton = document.createElement('button');
+    closeButton.innerText = 'X';
+
+    this.closeButton = closeButton;
+
+    head.appendChild(componentName);
+    head.appendChild(closeButton);
+
+    return head;
+  }
+
+  getUl() {
+    const ul = document.createElement('ul');
+
+    this.ul = ul;
+    return ul;
+  }
+
+  getMoreButton() {
+    const moreButton = document.createElement('button');
+    moreButton.className = 'more';
+    moreButton.innerText = '더보기';
+
+    this.moreButton = moreButton;
+    return moreButton;
+  }
+
+  appendLi(data) {
+    const log = new Log(data);
+    this.ul.appendChild(log.render());
+  }
+
+  fetchData() {
+    mockDatas.forEach((data) => {
+      this.logs.push(data);
+      this.appendLi(data);
+    });
+  }
+
+  openActivityLog() {
+    this.element.classList.remove('close');
+  }
+
+  setElement() {
+    const wrapper = this.getWrapper();
+
+    wrapper.appendChild(this.getHead());
+    wrapper.appendChild(this.getUl());
+    wrapper.appendChild(this.getMoreButton());
+
+    this.element = wrapper;
+  }
+
+  setEventListeners() {
+    this.closeButton.addEventListener('click', () => {
+      this.wrapper.classList.add('close');
+    });
+    this.moreButton.addEventListener('click', () => {
+      this.fetchData();
+    });
+    this.element.addEventListener('scroll', () => {
+      const scrollY = this.element.scrollHeight - this.element.scrollTop;
+      if (scrollY === this.element.clientHeight) {
+        this.fetchData();
+      }
+    });
+  }
+  render() {
+    this.setEventListeners();
+    this.fetchData();
+
+    return this.element;
+  }
+}

--- a/src/javascripts/Components/ActivityLog.js
+++ b/src/javascripts/Components/ActivityLog.js
@@ -5,7 +5,7 @@ import Log from './Log.js';
 import style from '../../stylesheets/activityLog.css';
 
 const mockData = {
-  data: '@hello',
+  user: '@hello',
   noteTitle: '집에가기',
   method: 'moved',
   columnFrom: 'Todo',

--- a/src/javascripts/Components/Header.js
+++ b/src/javascripts/Components/Header.js
@@ -4,6 +4,7 @@ export default class Header extends Element {
   constructor() {
     super();
 
+    this.menuButton = undefined;
     this.setElement();
   }
 
@@ -20,6 +21,8 @@ export default class Header extends Element {
     const menu_button = document.createElement('button');
     menu_button.innerText = 'menu';
     menu.appendChild(menu_button);
+
+    this.menuButton = menu_button;
 
     return menu;
   }

--- a/src/javascripts/Components/KanbanPage.js
+++ b/src/javascripts/Components/KanbanPage.js
@@ -1,6 +1,7 @@
 import Element from './Element.js';
 import Header from './Header.js';
 import Kanban from './Kanban.js';
+import ActivityLog from './ActivityLog.js';
 
 // eslint-disable-next-line no-unused-vars
 import kanban from '../../stylesheets/kanban.css';
@@ -58,6 +59,7 @@ export default class KanbanPage extends Element {
   constructor() {
     super();
     this.header = new Header();
+    this.activityLog = new ActivityLog();
     this.kanban = null;
 
     this.setElement();
@@ -70,11 +72,18 @@ export default class KanbanPage extends Element {
     }, 0);
   }
 
+  setEventListeners() {
+    this.header.menuButton.addEventListener('click', () => {
+      this.activityLog.openActivityLog();
+    });
+  }
+
   setElement() {
     const wrapper = document.createElement('div');
 
     wrapper.appendChild(this.header.render());
     this.fetchKanbanData();
+    wrapper.appendChild(this.activityLog.render());
 
     this.element = wrapper;
   }

--- a/src/javascripts/Components/Log.js
+++ b/src/javascripts/Components/Log.js
@@ -5,7 +5,7 @@ export default class Log extends Element {
     super();
 
     this.user = data.user;
-    this.noteTitle = data.title;
+    this.noteTitle = data.noteTitle;
     this.method = data.method;
     this.columnFrom = data.columnFrom;
     this.columnTo = data.columnTo;
@@ -49,7 +49,7 @@ export default class Log extends Element {
 
     if (this.method === 'moved') {
       log.appendChild(toP);
-      log.appendChild(columnFromP);
+      log.appendChild(columnToP);
     }
 
     return log;

--- a/src/javascripts/Components/Log.js
+++ b/src/javascripts/Components/Log.js
@@ -1,0 +1,63 @@
+import Element from './Element.js';
+
+export default class Log extends Element {
+  constructor(data) {
+    super();
+
+    this.user = data.user;
+    this.noteTitle = data.title;
+    this.method = data.method;
+    this.columnFrom = data.columnFrom;
+    this.columnTo = data.columnTo;
+
+    this.setElement();
+  }
+
+  getWrapper() {
+    const wrapper = document.createElement('li');
+    wrapper.appendChild(this.getLogDetail());
+
+    return wrapper;
+  }
+
+  getLogDetail() {
+    const log = document.createElement('div');
+    log.className = 'log';
+
+    const userP = document.createElement('p');
+    userP.className = 'user';
+    userP.innerText = this.user;
+    const methodP = document.createElement('p');
+    methodP.innerText = this.method;
+    const noteTitleP = document.createElement('p');
+    noteTitleP.className = 'title';
+    noteTitleP.innerText = this.noteTitle;
+    const fromP = document.createElement('p');
+    fromP.innerText = 'from';
+    const columnFromP = document.createElement('p');
+    columnFromP.innerText = this.columnFrom;
+    const toP = document.createElement('p');
+    toP.innerText = 'to';
+    const columnToP = document.createElement('p');
+    columnToP.innerText = this.columnTo;
+
+    log.appendChild(userP);
+    log.appendChild(methodP);
+    log.appendChild(noteTitleP);
+    log.appendChild(fromP);
+    log.appendChild(columnFromP);
+
+    if (this.method === 'moved') {
+      log.appendChild(toP);
+      log.appendChild(columnFromP);
+    }
+
+    return log;
+  }
+
+  setElement() {
+    const wrapper = this.getWrapper();
+
+    this.element = wrapper;
+  }
+}

--- a/src/javascripts/Components/Log.js
+++ b/src/javascripts/Components/Log.js
@@ -9,13 +9,13 @@ export default class Log extends Element {
     this.method = data.method;
     this.columnFrom = data.columnFrom;
     this.columnTo = data.columnTo;
+    this.time = data.time;
 
     this.setElement();
   }
 
   getWrapper() {
     const wrapper = document.createElement('li');
-    wrapper.appendChild(this.getLogDetail());
 
     return wrapper;
   }
@@ -55,8 +55,18 @@ export default class Log extends Element {
     return log;
   }
 
+  getTime() {
+    const timeP = document.createElement('p');
+    timeP.className = 'time';
+    timeP.innerText = this.time;
+
+    return timeP;
+  }
+
   setElement() {
     const wrapper = this.getWrapper();
+    wrapper.appendChild(this.getLogDetail());
+    wrapper.appendChild(this.getTime());
 
     this.element = wrapper;
   }

--- a/src/stylesheets/activityLog.css
+++ b/src/stylesheets/activityLog.css
@@ -1,0 +1,97 @@
+/* activity log */
+
+div#activity_log {
+  background-color: #ffffff;
+  border-left: solid 1px #000000;
+
+  position: fixed;
+  width: 500px;
+  height: 100vh;
+  right: 0;
+  top: 0;
+
+  z-index: 2000;
+
+  overflow-y: scroll;
+
+  transition: all 0.5s ease;
+}
+
+div#activity_log.close {
+  transform: translateX(500px);
+}
+
+div#activity_log .head {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+
+  height: 50px;
+  align-items: center;
+}
+
+div#activity_log .head div {
+  margin: 0 10px 0 10px;
+}
+
+div#activity_log ul {
+  list-style: none;
+  padding: 0;
+}
+
+div#activity_log ul li {
+  user-select: none;
+  padding: 10px;
+  margin: 2px 0 2px 0;
+
+  border-top: solid 1px #000000;
+  border-bottom: solid 1px #000000;
+}
+
+div#activity_log ul li div.log {
+  display: flex;
+  flex-direction: row;
+}
+
+div#activity_log ul li div.log p {
+  margin: 5px;
+}
+div#activity_log ul li div.log p.user,
+div#activity_log ul li div.log p.column,
+div#activity_log ul li div.log p.title {
+  color: #0000ff;
+  font-weight: bold;
+}
+
+div#activity_log ul li p.time {
+  margin: 5px;
+  color: #555555;
+}
+
+div#activity_log button.more {
+  width: calc(100% - 10px);
+  height: 30px;
+  padding: 0px;
+  margin: 5px;
+  border: solid 1px #000000;
+
+  border-radius: 7px;
+
+  transition: all 0.2s ease;
+}
+
+div#activity_log button.more:active {
+  outline: none;
+}
+
+div#activity_log button.more:focus {
+  outline: none;
+}
+
+div#activity_log button.more:hover {
+  background-color: #dddddd;
+}
+
+div#activity_log button.more:active {
+  background-color: #cccccc;
+}


### PR DESCRIPTION
> 칸반 페이지에 액티비티 로그 컴포넌트를 추가함

## related issue

- #3 
- #28 (mock 함수만 만들어놓음)
- #29 

## 설명 (what, why)


칸반 페이지에 위치한 이유는 칸반 페이지가 header를 가지고 있기 때문에, 액티비티 로그 컴포넌트를 칸반 페이지에 적용함

header의 메뉴 버튼을 눌러야 액티비티 로그가 나와야 함.

액티비티 로그에는 시작시 데이터를 받아오는 내용과, 페이지네이션 기능을 API 통신 없이 간단하게 구현함

로그 컴포넌트를 구분하기 위해 액티비티 로그 창과 로그에 대한 컴포넌트를 분리함.

각 로그에 들어가는 데이터의 형태는 다음과 같다

```json
{
  "user": "@유저네임",
  "noteTitle": "해당노트제목",
  "method": "로그작업타입",
  "columnFrom": "발생한컬럼",
  "columnTo": "이동한경우컬럼",
  "time": "시간"
};
```