### PR TITLE
[#40] fix: 추가 - 마우스 왼쪽 버튼으로만 동작

### DIFF
--- a/src/javascripts/Components/Kanban.js
+++ b/src/javascripts/Components/Kanban.js
@@ -103,6 +103,11 @@ export default class Kanban extends Element {
   }
 
   _mousedown(event) {
+    // 왼쪽 클릭 & 터치 이벤트 인 경우에만 동작하도록 설정
+    if (event.button !== 0) {
+      return;
+    }
+
     this.clicked = true;
     targetRemove = event.target.closest('li');
 


### PR DESCRIPTION
> 정상적인 동작만 가능하도록, 마우스 왼쪽클릭 (터치) 로만 동작하도록 설정

## related issue

- #40

## 설명 (what, why)

마우스 오른쪽 버튼을 누르는 경우, mousedown 이벤트는 발생하지만 mouseup 이벤트의 경우 제대로 동작하지 않는 버그가 존재함

따라서 mousedown 이벤트 핸들러에 safe guard를 추가함
