### PR TITLE
PR: 추가 - 칸반페이지 event handler 버그 수정, 노트이동 기능 추가

### DIFF
--- a/src/javascripts/Components/Column.js
+++ b/src/javascripts/Components/Column.js
@@ -135,7 +135,7 @@ export default class Column extends Element {
     const count = this.element.querySelector('.count');
     count.innerText = this.notes.length;
 
-    console.log(this.notes);
+    // console.log(this.notes);
   }
 
   appendNote(data) {
@@ -169,7 +169,6 @@ export default class Column extends Element {
       this.form.classList.add('hidden');
     });
     this.textArea.addEventListener('keydown', () => {
-      // console.log(this.textArea.value);
       this.form.classList.remove('disable');
     });
     this.textArea.addEventListener('keyup', () => {

--- a/src/javascripts/Components/Hover.js
+++ b/src/javascripts/Components/Hover.js
@@ -7,12 +7,9 @@ export default class Hover extends Element {
     this.setElement();
   }
 
-  changeInnerDom(dom, x, y) {
+  changeInnerDom(dom) {
     this.target = dom;
     this.element.appendChild(this.target);
-
-    this.element.style.left = x - this.element.offsetWidth / 2 + 'px';
-    this.element.style.top = y - this.element.offsetHeight / 2 + 'px';
   }
 
   clearInnerDom() {

--- a/src/javascripts/Components/Kanban.js
+++ b/src/javascripts/Components/Kanban.js
@@ -76,11 +76,26 @@ export default class Kanban extends Element {
     hover.element.hidden = true;
     const elemBelow = document.elementFromPoint(pageX, pageY);
     const li = elemBelow.closest('li');
+    const column = elemBelow.closest('.column');
     hover.element.hidden = false;
 
     hover.tracking(pageX, pageY);
 
     if (!li || !this.li) {
+      if (column) {
+        const ul = column.querySelector('ul');
+
+        const start = ul.querySelector('.start_point');
+        const { top } = start.getBoundingClientRect();
+
+        if (top > pageY) {
+          // insertfirst
+          ul.insertBefore(this.li, start.nextSibling);
+        } else {
+          // insertlast
+          ul.appendChild(this.li);
+        }
+      }
       return;
     }
 
@@ -108,13 +123,13 @@ export default class Kanban extends Element {
       return;
     }
 
-    this.clicked = true;
     targetRemove = event.target.closest('li');
 
     if (!targetRemove || targetRemove.className === 'start_point') {
       return;
     }
 
+    this.clicked = true;
     this.li = targetRemove.cloneNode(true);
     this.li.classList.add('temp_space');
 

--- a/src/javascripts/Components/Kanban.js
+++ b/src/javascripts/Components/Kanban.js
@@ -133,11 +133,8 @@ export default class Kanban extends Element {
     this.li = targetRemove.cloneNode(true);
     this.li.classList.add('temp_space');
 
-    hover.changeInnerDom(
-      targetRemove.cloneNode(true),
-      event.pageX,
-      event.pageY,
-    );
+    hover.changeInnerDom(targetRemove.cloneNode(true));
+    hover.element.hidden = true;
   }
 
   _mouseup() {
@@ -190,10 +187,16 @@ export default class Kanban extends Element {
     hover.clearInnerDom();
   }
 
+  _dblclick() {
+    // double click은 한번 더블클릭 한 뒤에 바로 같은 좌표에서 더블클릭 시 또 다시 발생하지 않음
+    // 모달 오픈
+  }
+
   setEventListeners() {
     this.element.addEventListener('mousemove', this._mousemove);
     this.element.addEventListener('mousedown', this._mousedown);
     this.element.addEventListener('mouseup', this._mouseup);
     this.element.addEventListener('mouseleave', this._mouseleave);
+    this.element.addEventListener('dblclick', this._dblclick);
   }
 }

--- a/src/javascripts/Components/Kanban.js
+++ b/src/javascripts/Components/Kanban.js
@@ -165,6 +165,8 @@ export default class Kanban extends Element {
     if (!this.clicked) {
       return;
     }
+
+    this.clicked = false;
     if (this.li) {
       this.li.classList.remove('temp_space');
 

--- a/src/stylesheets/kanban.css
+++ b/src/stylesheets/kanban.css
@@ -91,7 +91,7 @@ body section {
   background-color: #444444;
 
   text-align: center;
-
+  user-select: none;
   font-size: 0.8rem;
 }
 
@@ -102,6 +102,7 @@ body section {
 
 .kanban .column .head div.buttons {
   margin-right: 5px;
+  user-select: none;
 }
 
 .kanban .column .head div.buttons button {
@@ -133,6 +134,14 @@ body section {
   word-break: break-all;
 
   background-color: #ffffff;
+}
+
+.kanban .column ul li.start_point {
+  height: 0;
+  border-radius: 0;
+  padding: 0;
+  margin: 0;
+  border: none;
 }
 
 .kanban .column ul li.temp_space {


### PR DESCRIPTION
> 칸반 페이지 event handler 버그 수정 & 사용자 입장에서 기능 추가

## related issue

- #3 
- #18 
- #26

## 설명 (what, why)

노트 드래그 시, 이동할 다른 노트에 닿지 않고 컬럼 내에 위치만 하면 노트를 이동하도록 설정

더블클릭으로 모달을 띄우기 위해 더블클릭 핸들러 설정

마우스가 브라우저를 떠낫을 때 clicked를 false로 바꾸는 코드가 누락됨을 확인.

이를 고침

이를 그대로 둘 경우 mousemove 이벤트 핸들러가 계속 동작해 (clicked로 safe guard를 생성한 구조임) 에러가 발생함