### PR TITLE
PR: 추가 - 칸반 데이터를 가져오는 API

### DIFF
--- a/apis/constants/message.js
+++ b/apis/constants/message.js
@@ -15,4 +15,16 @@ module.exports = {
     TEXT: '알 수 없는 오류가 발생했습니다.',
     STATUS_CODE: 503,
   },
+  GET_KANBAN_SUCCESS: {
+    TEXT: '성공적으로 데이터를 가져왔습니다',
+    STATUS_CODE: 200,
+  },
+  GET_KANBAN_ERROR: {
+    TEXT: '존재하지 않는 kanban입니다',
+    STATUS_CODE: 404,
+  },
+  GET_KANBAN_MYSQL_ERROR: {
+    TEXT: '서버에서 에러가 발생했습니다.',
+    STATUS_CODE: 500,
+  },
 };

--- a/apis/index.js
+++ b/apis/index.js
@@ -1,8 +1,10 @@
 const express = require('express');
 const loginRouter = require('./login');
+const kanbanRouter = require('./kanban');
 
 const router = express.Router();
 
 router.use(loginRouter);
+router.use(kanbanRouter);
 
 module.exports = router;

--- a/apis/kanban.js
+++ b/apis/kanban.js
@@ -1,0 +1,37 @@
+const express = require('express');
+const dao = require('../dao/dao.js');
+const safePromise = require('../utils/safePromise');
+
+const MESSAGE = require('./constants/message');
+
+const router = express.Router();
+
+router.get('/get/:kanbanId', async (req, res) => {
+  const result = {
+    success: false,
+    message: '',
+  };
+  const { kanbanId } = req.params;
+
+  const [data, error] = await safePromise(
+    dao.getKanbanData(parseInt(kanbanId)),
+  );
+  if (error) {
+    result.message = MESSAGE.GET_KANBAN_MYSQL_ERROR.TEXT;
+    res.status(MESSAGE.GET_KANBAN_MYSQL_ERROR.STATUS_CODE).json(result);
+    return;
+  }
+
+  if (data === undefined) {
+    result.message = MESSAGE.GET_KANBAN_ERROR.TEXT;
+    res.status(MESSAGE.GET_KANBAN_ERROR.STATUS_CODE).json(result);
+    return;
+  }
+
+  result.success = true;
+  result.message = MESSAGE.GET_KANBAN_SUCCESS.TEXT;
+  result.data = data;
+  res.status(MESSAGE.GET_KANBAN_SUCCESS.STATUS_CODE).json(result);
+});
+
+module.exports = router;

--- a/dao/DataAccessObject.js
+++ b/dao/DataAccessObject.js
@@ -2,10 +2,14 @@ const mysql = require('mysql2');
 const crypto = require('crypto');
 const CONFIG = require('./constants/config');
 const TABLE = require('./constants/table');
+
 const User = require('./dto/User');
 const UserToken = require('./dto/UserToken');
+
 const safePromise = require('../utils/safePromise');
 const dt = require('../utils/datetime');
+
+const getKanbanData = require('./method/getKanbanData');
 
 class DataAccessObject {
   constructor(option) {
@@ -127,5 +131,7 @@ class DataAccessObject {
     return new UserToken(rows[0]);
   }
 }
+
+DataAccessObject.prototype.getKanbanData = getKanbanData;
 
 module.exports = DataAccessObject;

--- a/dao/DataAccessObject.spec.js
+++ b/dao/DataAccessObject.spec.js
@@ -18,5 +18,12 @@ test('return a user object', async () => {
     profile_image: '{filename}',
   });
 
+  // dao.endPool();
+});
+
+test('get note rows test', async () => {
+  const kanbanRows = await dao.getKanbanData(1);
+
+  console.log(kanbanRows);
   dao.endPool();
 });

--- a/dao/dto/Column.js
+++ b/dao/dto/Column.js
@@ -1,0 +1,9 @@
+class Column {
+  constructor(id, title) {
+    this.id = id;
+    this.title = title;
+    this.notes = [];
+  }
+}
+
+module.exports = Column;

--- a/dao/dto/Kanban.js
+++ b/dao/dto/Kanban.js
@@ -1,0 +1,9 @@
+class Kanban {
+  constructor(id, title) {
+    this.id = id;
+    this.title = title;
+    this.columns = [];
+  }
+}
+
+module.exports = Kanban;

--- a/dao/dto/Note.js
+++ b/dao/dto/Note.js
@@ -1,0 +1,9 @@
+class Note {
+  constructor(id, content, user) {
+    this.id = id;
+    this.content = content;
+    this.user = user;
+  }
+}
+
+module.exports = Note;

--- a/dao/method/getKanbanData.js
+++ b/dao/method/getKanbanData.js
@@ -19,6 +19,9 @@ module.exports = async function get(kanbanId) {
   if (kanbanRowError) {
     throw kanbanRowError;
   }
+  if (kanbanRow.length === 0) {
+    return undefined;
+  }
 
   const { title } = kanbanRow[0];
 

--- a/dao/method/getKanbanData.js
+++ b/dao/method/getKanbanData.js
@@ -1,0 +1,92 @@
+const safePromise = require('../../utils/safePromise');
+
+const Kanban = require('../dto/Kanban');
+const Column = require('../dto/Column');
+const Note = require('../dto/Note');
+
+module.exports = async function get(kanbanId) {
+  const [connection, connectionError] = await safePromise(this.getConnection());
+  if (connectionError) {
+    throw connectionError;
+  }
+
+  const [kanbanRow, kanbanRowError] = await safePromise(
+    this.executeQuery(connection, `SELECT title FROM KANBAN WHERE id = ?`, [
+      kanbanId,
+    ]),
+  );
+
+  if (kanbanRowError) {
+    throw kanbanRowError;
+  }
+
+  const { title } = kanbanRow[0];
+
+  const [rows, rowsError] = await safePromise(
+    this.executeQuery(
+      connection,
+      `SELECT 
+        J.columnId as 'columnId', J.columnTitle as 'columnTitle', 
+        J.noteId as 'noteId', J.user_id as 'user_id', U.name as 'userName', 
+        J.content as 'content', J.prevNoteId as 'prevNoteId', J.nextNoteId as 'nextNoteId'
+      FROM 
+      (
+        SELECT 
+          C.id as 'columnId', C.title as 'columnTitle', N.id as 'noteId', 
+          N.user_id as 'user_id', N.content as 'content', N.prev_note_id as 'prevNoteId', 
+          N.next_note_id as 'nextNoteId'
+        FROM \`COLUMN\` as C 
+        LEFT JOIN NOTE as N
+        ON C.id = N.column_id 
+        WHERE C.kanban_id = ?
+        ORDER BY C.order
+      ) AS J
+      LEFT JOIN USER AS U
+      ON J.user_id = U.id`,
+      [kanbanId],
+    ),
+  );
+
+  if (rowsError) {
+    throw rowsError;
+  }
+
+  connection.release();
+
+  const kanban = new Kanban(kanbanId, title);
+  const columnsMap = new Map();
+  const notesMap = new Map();
+  const startsMap = new Map(); // 각 column의 시작점
+
+  // rows를  순회하며 위 Map에 key, value로 데이터를 저장
+  rows.forEach((row) => {
+    if (!columnsMap.has(row.columnId)) {
+      const column = new Column(row.columnId, row.columnTitle);
+      columnsMap.set(row.columnId, column);
+    }
+
+    if (row.prevNoteId === null) {
+      startsMap.set(row.columnId, row.noteId);
+    }
+
+    const note = new Note(row.noteId, row.content, row.userName);
+    notesMap.set(row.noteId, {
+      data: note,
+      prevId: row.prevNoteId,
+      nextId: row.nextNoteId,
+    });
+  });
+
+  columnsMap.forEach((column) => {
+    const startNoteId = startsMap.get(column.id);
+    let note = notesMap.get(startNoteId);
+
+    while (note !== undefined) {
+      column.notes.push(note.data);
+      note = notesMap.get(note.nextId);
+    }
+    kanban.columns.push(column);
+  });
+
+  return kanban;
+};


### PR DESCRIPTION
> GET 요청으로 kanban id를 받으면 해당 칸반보드의 데이터를 가공해 return 하는 api

## related issue

- #22 

## 설명 (what, why)

URL 경로 : /api/get/:kanban_id

SQL로 받아온 rows를 가공할 때 사용할 DTO class들 생성함
- 칸반
- 컬럼
- 노트

### SQL

인자로 받은 kanban_id와 연관된 note들을 전부 가져오되, column 정보와 함께 join 해서 가져옴.

이 때 column의 순서는 order로 관리하므로, ORDER BY를 사용함

### DAO

DAO의 method로 직접 작성할 경우 DAO가 비대해지는 문제가 있어, getKanbanData를 메소드로 따로 작성하고, prototype으로 선언해 사용함

bind(this)를 이용해 내부 method에서 처리하려 했으나 제대로 동작하지않는 문제가 있어 prototype 사용

### 데이터가공

받아온 rows를 column별로, note별로 가공 작업을 진행

DTO로 전송할 때 가공된 데이터를 전송하기 위해 method에서 가공을 처리함

가공 작업 시, Map 객체를 이용해 logN으로 탐색을 진행해 속도를 향상함. 따라서 가공의 최종 시간 복잡도는 N + NlogN