### PR TITLE
PR: 추가 - kanban 페이지 데이터 fetching

### DIFF
--- a/src/javascripts/Components/Column.js
+++ b/src/javascripts/Components/Column.js
@@ -6,14 +6,14 @@ export default class Column extends Element {
     super();
 
     this.notes = [];
-    this.key = data.key;
+    this.id = data.id;
     this.title = data.title;
     this.head = undefined;
     this.ul = undefined;
 
     data.notes.forEach((note) => {
       this.notes.push({
-        key: note.key,
+        id: note.id,
         data: note,
         dom: new Note(note),
       });
@@ -24,7 +24,7 @@ export default class Column extends Element {
 
   getWrapper() {
     const wrapper = document.createElement('div');
-    wrapper.dataset.key = this.key;
+    wrapper.dataset.id = this.id;
     wrapper.className = 'column';
     return wrapper;
   }
@@ -113,7 +113,7 @@ export default class Column extends Element {
 
   pickNote(noteKey) {
     const targetIndex = this.notes.findIndex((cur) => {
-      return cur.key === parseInt(noteKey);
+      return cur.id === parseInt(noteKey);
     });
     if (targetIndex === -1) {
       return;
@@ -140,7 +140,7 @@ export default class Column extends Element {
 
   appendNote(data) {
     const noteObject = {
-      key: data.key,
+      id: data.id,
       data: data,
       dom: new Note(data),
     };
@@ -182,9 +182,9 @@ export default class Column extends Element {
       }
 
       const noteObject = {
-        key: 123,
-        title: this.textArea.value,
-        name: 'ADMIN',
+        id: 123,
+        content: this.textArea.value,
+        user: 'ADMIN',
       };
 
       this.appendNote(noteObject);

--- a/src/javascripts/Components/Kanban.js
+++ b/src/javascripts/Components/Kanban.js
@@ -21,17 +21,16 @@ export default class Kanban extends Element {
   constructor(data) {
     super();
 
-    this.key = data.key;
+    this.id = data.id;
     this.columns = [];
-
     data.columns.forEach((column) => {
       const columnObject = {
-        key: column.key,
+        id: column.id,
         data: column,
         dom: new Column(column),
       };
       this.columns.push(columnObject);
-      columnsMap.set(column.key, columnObject);
+      columnsMap.set(column.id, columnObject);
     });
 
     this.hover = new Hover();
@@ -46,7 +45,7 @@ export default class Kanban extends Element {
     const wrapper = document.createElement('div');
     wrapper.className = 'kanban';
     wrapper.id = 'mytodo';
-    wrapper.dataset.key = this.key;
+    wrapper.dataset.id = this.id;
 
     return wrapper;
   }
@@ -107,10 +106,10 @@ export default class Kanban extends Element {
 
     // delete hover target
     if (targetRemove) {
-      const { key } = targetRemove.closest('.column').dataset;
-      const columnObject = columnsMap.get(parseInt(key)).dom;
+      const { id } = targetRemove.closest('.column').dataset;
+      const columnObject = columnsMap.get(parseInt(id)).dom;
 
-      targetData = columnObject.pickNote(targetRemove.dataset.key);
+      targetData = columnObject.pickNote(targetRemove.dataset.id);
 
       targetRemove.remove();
       targetRemove = undefined;
@@ -142,13 +141,13 @@ export default class Kanban extends Element {
     if (this.li && this.li.closest('.column')) {
       this.li.classList.remove('temp_space');
 
-      const { key } = this.li.closest('.column').dataset;
-      const columnObject = columnsMap.get(parseInt(key)).dom;
+      const { id } = this.li.closest('.column').dataset;
+      const columnObject = columnsMap.get(parseInt(id)).dom;
       const ul = columnObject.element.querySelector('ul');
 
       let index = -1;
       Array.from(ul.children).forEach((cur, idx) => {
-        if (parseInt(cur.dataset.key) === targetData.key) {
+        if (parseInt(cur.dataset.id) === targetData.id) {
           index = idx;
         }
       });
@@ -170,13 +169,13 @@ export default class Kanban extends Element {
     if (this.li) {
       this.li.classList.remove('temp_space');
 
-      const { key } = this.li.closest('.column').dataset;
-      const columnObject = columnsMap.get(parseInt(key)).dom;
+      const { id } = this.li.closest('.column').dataset;
+      const columnObject = columnsMap.get(parseInt(id)).dom;
       const ul = columnObject.element.querySelector('ul');
 
       let index = -1;
       Array.from(ul.children).forEach((cur, idx) => {
-        if (parseInt(cur.dataset.key) === targetData.key) {
+        if (parseInt(cur.dataset.id) === targetData.id) {
           index = idx;
         }
       });

--- a/src/javascripts/Components/KanbanPage.js
+++ b/src/javascripts/Components/KanbanPage.js
@@ -6,55 +6,6 @@ import ActivityLog from './ActivityLog.js';
 // eslint-disable-next-line no-unused-vars
 import kanban from '../../stylesheets/kanban.css';
 
-const data = {
-  key: '1',
-  columns: [
-    {
-      key: 1,
-      title: 'Todo',
-      notes: [
-        {
-          key: 1,
-          title: '첫번쨰 할일',
-          name: 'crong',
-        },
-        {
-          key: 2,
-          title: '두번쨰 할일',
-          name: 'pobi',
-        },
-      ],
-    },
-    {
-      key: 2,
-      title: 'Doing',
-      notes: [
-        {
-          key: 3,
-          title: '세번쨰 할일',
-          name: 'woowa',
-        },
-        {
-          key: 4,
-          title: '네번쨰 할일',
-          name: 'boost',
-        },
-      ],
-    },
-    {
-      key: 3,
-      title: 'Done',
-      notes: [
-        {
-          key: 5,
-          title: '다섯번쨰 할일',
-          name: 'superman',
-        },
-      ],
-    },
-  ],
-};
-
 export default class KanbanPage extends Element {
   constructor() {
     super();
@@ -66,10 +17,21 @@ export default class KanbanPage extends Element {
   }
 
   fetchKanbanData() {
-    setTimeout(() => {
-      this.kanban = new Kanban(data).render();
-      this.element.appendChild(this.kanban);
-    }, 0);
+    const kanbanId = 1;
+    fetch(`/api/get/${kanbanId}`, {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+        Accept: 'application/json',
+      },
+    })
+      .then((res) => res.json())
+      .then((res) => {
+        console.log('fetch complete');
+
+        this.kanban = new Kanban(res.data).render();
+        this.element.appendChild(this.kanban);
+      });
   }
 
   setEventListeners() {

--- a/src/javascripts/Components/Note.js
+++ b/src/javascripts/Components/Note.js
@@ -4,16 +4,16 @@ export default class Note extends Element {
   constructor(data) {
     super();
 
-    this.key = data.key;
-    this.title = data.title;
-    this.name = data.name;
+    this.id = data.id;
+    this.content = data.content;
+    this.user = data.user;
 
     this.setElement();
   }
 
   getWrapper() {
     const li = document.createElement('li');
-    li.dataset.key = this.key;
+    li.dataset.id = this.id;
 
     return li;
   }
@@ -26,7 +26,7 @@ export default class Note extends Element {
     p.innerText = 'Add by';
     const p_writter = document.createElement('p');
     p_writter.className = 'writter';
-    p_writter.innerText = `${this.name}`;
+    p_writter.innerText = `${this.user}`;
     footer.appendChild(p);
     footer.appendChild(p_writter);
 
@@ -36,7 +36,7 @@ export default class Note extends Element {
   getSection() {
     const section = document.createElement('section');
     section.className = 'content';
-    section.innerText = `${this.title}`;
+    section.innerText = `${this.content}`;
 
     return section;
   }


### PR DESCRIPTION
> 칸반보드 페이지에서 칸반 데이터를 API에서 요청해 사용하도록 설정

## related issue

- #3
- #22 

## 설명 (what, why)

작성한 API들에 맞추어 class들의 key 값을 수정함


기존 hard coding 되어있던 코드를 제거하고 API 에서 data를 fetch해서 가져 오도록 수정

fetching 작업은 비동기로 진행되지만, 이후에 앞서 결과를 사용하지 않아도 되므로 async 함수로 작성하지 않음