### PR TITLE
PR: 추가 - 노트 추가 API

### DIFF
--- a/apis/constants/message.js
+++ b/apis/constants/message.js
@@ -27,4 +27,16 @@ module.exports = {
     TEXT: '서버에서 에러가 발생했습니다.',
     STATUS_CODE: 500,
   },
+  PUT_NOTE_SUCCESS: {
+    TEXT: '노트의 추가가 성공적으로 완료되었습니다.',
+    STATUS_CODE: 200,
+  },
+  PUT_NOTE_ERROR: {
+    TEXT: '노트의 추가에 문제가 있습니다',
+    STATUS_CODE: 500,
+  },
+  PUT_NOTE_BODY_ERROR: {
+    TEXT: '데이터의 부족합니다.',
+    STATUS_CODE: 500,
+  },
 };

--- a/apis/kanban.js
+++ b/apis/kanban.js
@@ -6,6 +6,16 @@ const MESSAGE = require('./constants/message');
 
 const router = express.Router();
 
+/**
+ * @api {get} /user/:id Request User information
+ * @apiName GetUser
+ * @apiGroup User
+ *
+ * @apiParam {Number} id Users unique ID.
+ *
+ * @apiSuccess {String} firstname Firstname of the User.
+ * @apiSuccess {String} lastname  Lastname of the User.
+ */
 router.get('/get/:kanbanId', async (req, res) => {
   const result = {
     success: false,
@@ -32,6 +42,51 @@ router.get('/get/:kanbanId', async (req, res) => {
   result.message = MESSAGE.GET_KANBAN_SUCCESS.TEXT;
   result.data = data;
   res.status(MESSAGE.GET_KANBAN_SUCCESS.STATUS_CODE).json(result);
+});
+
+/**
+ * @api {get} /user/:id Request User information
+ * @apiName GetUser
+ * @apiGroup User
+ *
+ * @apiParam {Number} id Users unique ID.
+ *
+ * @apiSuccess {String} firstname Firstname of the User.
+ * @apiSuccess {String} lastname  Lastname of the User.
+ */
+router.put('/column/:columnId', async (req, res) => {
+  const result = {
+    success: false,
+    message: '',
+  };
+  const { columnId } = req.params;
+  const { user, userId, content } = req.body;
+
+  if (!user || !userId || !content) {
+    result.message = MESSAGE.PUT_NOTE_ERROR.TEXT;
+    res.status(MESSAGE.PUT_NOTE_ERROR.STATUS_CODE).json(result);
+    return;
+  }
+
+  const data = {
+    user,
+    userId,
+    content,
+  };
+
+  const [note, error] = await safePromise(
+    dao.createNote(parseInt(columnId), data),
+  );
+  if (error) {
+    result.message = MESSAGE.PUT_NOTE_BODY_ERROR.TEXT;
+    res.status(MESSAGE.PUT_NOTE_BODY_ERROR.STATUS_CODE).json(result);
+    return;
+  }
+
+  result.success = true;
+  result.message = MESSAGE.PUT_NOTE_SUCCESS.TEXT;
+  result.data = data;
+  res.status(MESSAGE.PUT_NOTE_SUCCESS.STATUS_CODE).json(result);
 });
 
 module.exports = router;

--- a/apis/kanban.js
+++ b/apis/kanban.js
@@ -7,14 +7,14 @@ const MESSAGE = require('./constants/message');
 const router = express.Router();
 
 /**
- * @api {get} /user/:id Request User information
- * @apiName GetUser
- * @apiGroup User
+ * @api {get} /get/:kanbanId Kanban 데이터 요청
+ * @apiName get kanban
+ * @apiGroup Kanban
  *
- * @apiParam {Number} id Users unique ID.
+ * @apiParam {Number} kanbanId kanban 보드의 id [params]
  *
- * @apiSuccess {String} firstname Firstname of the User.
- * @apiSuccess {String} lastname  Lastname of the User.
+ * @apiSuccess {Boolean} success API 호출 성공 여부
+ * @apiSuccess {String} message 응답 결과 메시지
  */
 router.get('/get/:kanbanId', async (req, res) => {
   const result = {
@@ -45,14 +45,17 @@ router.get('/get/:kanbanId', async (req, res) => {
 });
 
 /**
- * @api {get} /user/:id Request User information
- * @apiName GetUser
- * @apiGroup User
+ * @api {put} /column/:columnId Column에 노트 정보를 추가함
+ * @apiName create new note
+ * @apiGroup kanban
  *
- * @apiParam {Number} id Users unique ID.
+ * @apiParam {Number} columnId 칸반보드의 id [params]
+ * @apiParam {String} user 유저의 닉네임 [body]
+ * @apiParam {Number} userId 유저의 id값 [body]
+ * @apiParam {String} content 노트의 내용 [body]
  *
- * @apiSuccess {String} firstname Firstname of the User.
- * @apiSuccess {String} lastname  Lastname of the User.
+ * @apiSuccess {Boolean} success API 호출 성공 여부
+ * @apiSuccess {String} message 응답 결과 메시지
  */
 router.put('/column/:columnId', async (req, res) => {
   const result = {
@@ -85,7 +88,7 @@ router.put('/column/:columnId', async (req, res) => {
 
   result.success = true;
   result.message = MESSAGE.PUT_NOTE_SUCCESS.TEXT;
-  result.data = data;
+  result.data = note;
   res.status(MESSAGE.PUT_NOTE_SUCCESS.STATUS_CODE).json(result);
 });
 

--- a/dao/DataAccessObject.js
+++ b/dao/DataAccessObject.js
@@ -1,4 +1,4 @@
-const mysql = require('mysql2');
+const mysql = require('mysql2/promise');
 const crypto = require('crypto');
 const CONFIG = require('./constants/config');
 const TABLE = require('./constants/table');
@@ -16,31 +16,17 @@ class DataAccessObject {
     this.pool = mysql.createPool(option);
   }
 
-  getConnection() {
-    return new Promise((resolve, reject) => {
-      this.pool.getConnection(function (err, connection) {
-        if (err) {
-          return reject(err);
-        }
-        resolve(connection);
-      });
-    });
+  async getConnection() {
+    return await this.pool.getConnection();
   }
 
   endPool() {
     this.pool.end();
   }
 
-  executeQuery(connection, sql, preparedStatement) {
-    return new Promise((resolve, reject) => {
-      connection.execute(sql, preparedStatement, (err, rows) => {
-        if (err) {
-          reject(err);
-        }
-
-        resolve(rows);
-      });
-    });
+  async executeQuery(connection, sql, preparedStatement) {
+    const execute = await connection.execute(sql, preparedStatement);
+    return execute[0];
   }
 
   async isConnectSuccess() {

--- a/dao/DataAccessObject.js
+++ b/dao/DataAccessObject.js
@@ -10,6 +10,7 @@ const safePromise = require('../utils/safePromise');
 const dt = require('../utils/datetime');
 
 const getKanbanData = require('./method/getKanbanData');
+const createNote = require('./method/createNote');
 
 class DataAccessObject {
   constructor(option) {
@@ -119,5 +120,6 @@ class DataAccessObject {
 }
 
 DataAccessObject.prototype.getKanbanData = getKanbanData;
+DataAccessObject.prototype.createNote = createNote;
 
 module.exports = DataAccessObject;

--- a/dao/DataAccessObject.spec.js
+++ b/dao/DataAccessObject.spec.js
@@ -17,13 +17,27 @@ test('return a user object', async () => {
     name: 'CAMP',
     profile_image: '{filename}',
   });
-
-  // dao.endPool();
 });
 
 test('get note rows test', async () => {
-  const kanbanRows = await dao.getKanbanData(1);
+  const kanban = await dao.getKanbanData(1);
 
-  console.log(kanbanRows);
+  expect(kanban.id).toEqual(1);
+  expect(kanban.title).toEqual('test');
+});
+
+test('insert note rows test', async () => {
+  const newNoteData = {
+    userId: 1,
+    user: 'TEST',
+    content: 'INSERT DAO TEST',
+  };
+  const note = await dao.createNote(1, newNoteData);
+
+  expect(note.user).toEqual(newNoteData.user);
+  expect(note.content).toEqual(newNoteData.content);
+});
+
+afterAll(() => {
   dao.endPool();
 });

--- a/dao/dto/Note.js
+++ b/dao/dto/Note.js
@@ -1,8 +1,9 @@
 class Note {
-  constructor(id, content, user) {
+  constructor(id, content, user, userId) {
     this.id = id;
     this.content = content;
     this.user = user;
+    this.userId = userId;
   }
 }
 

--- a/dao/method/createNote.js
+++ b/dao/method/createNote.js
@@ -22,7 +22,7 @@ module.exports = async function setNote(columnId, noteData) {
   let result = false;
 
   try {
-    // await connection.beginTransaction();
+    await connection.beginTransaction();
 
     // GET LAST NOTE OF THIS COLUMN
     // ?: column_id
@@ -69,9 +69,9 @@ module.exports = async function setNote(columnId, noteData) {
       noteData.userId,
     );
 
-    // await connection.commit();
+    await connection.commit();
   } catch (error) {
-    // connection.rollback();
+    connection.rollback();
   } finally {
     connection.release();
   }

--- a/dao/method/createNote.js
+++ b/dao/method/createNote.js
@@ -1,0 +1,80 @@
+const safePromise = require('../../utils/safePromise');
+
+const Note = require('../dto/Note');
+
+const SELECT_LAST_NOTE = `SELECT id from NOTE
+WHERE column_id = ? AND next_note_id is null;`;
+
+const INSERT_NOTE = `INSERT INTO NOTE 
+(column_id, user_id, \`content\`, prev_note_id, next_note_id)
+VALUES (?, ?, ?, ?, null);
+`;
+
+const UPDATE_LAST_NOTE = `UPDATE NOTE
+SET next_note_id = ?
+WHERE id = ?;`;
+
+module.exports = async function setNote(columnId, noteData) {
+  const [connection, connectionError] = await safePromise(this.getConnection());
+  if (connectionError) {
+    throw connectionError;
+  }
+  let result = false;
+
+  try {
+    // await connection.beginTransaction();
+
+    // GET LAST NOTE OF THIS COLUMN
+    // ?: column_id
+    const [lastNoteRow, lastNoteRowError] = await safePromise(
+      this.executeQuery(connection, SELECT_LAST_NOTE, [columnId]),
+    );
+
+    if (lastNoteRow.length === 0 || lastNoteRowError) {
+      throw new Error();
+    }
+
+    const lastNoteId = lastNoteRow[0].id;
+
+    // INSERT NOTE
+    // ?: column_id, user_id, content, prev_note_id
+    const [noteRow, noteRowError] = await safePromise(
+      this.executeQuery(connection, INSERT_NOTE, [
+        columnId,
+        noteData.userId,
+        noteData.content,
+        lastNoteId,
+      ]),
+    );
+
+    if (noteRowError) {
+      throw new Error();
+    }
+    const { insertId } = noteRow;
+
+    // UPDATE NOTE
+    // ?: next_note_id, id
+    const [updateRow, updateRowError] = await safePromise(
+      this.executeQuery(connection, UPDATE_LAST_NOTE, [insertId, lastNoteId]),
+    );
+
+    if (updateRowError) {
+      throw new Error();
+    }
+
+    result = new Note(
+      insertId,
+      noteData.content,
+      noteData.user,
+      noteData.userId,
+    );
+
+    // await connection.commit();
+  } catch (error) {
+    // connection.rollback();
+  } finally {
+    connection.release();
+  }
+
+  return result;
+};


### PR DESCRIPTION
> columnId와 노트 정보를 입력받아 해당 column 맨 앞에 새 노트를 추가하는 API 제작

## related issue

- #14

## 설명 (what, why)

!!트랜잭션을 사용하기 위해 모듈을 mysql2/promise로 변경함

새로운 노트를 생성하는 DAO method 추가
순서는 다음과 같음
- 칼럼의 맨 앞에 있는 노트의 id를 가져옴
- 그 노트 앞에 새로운 노트를 추가함 (이전에 받은 id값으로 연결구조 생성)
- 이전에 맨 앞에 있던 노트의 연결구조를 update함

테스트 코드의 pool을 끝내는 endPool을 맨 afterAll에 따로 할당. 

이는 endPool을 맨 마지막에 실행하기 위함