### PR TITLE
PR: 추가 - 노트 추가시 DB에도 저장

### DIFF
--- a/src/javascripts/Components/Column.js
+++ b/src/javascripts/Components/Column.js
@@ -181,16 +181,34 @@ export default class Column extends Element {
         return;
       }
 
-      const noteObject = {
-        id: 123,
+      const body = {
+        user: 'tester',
+        userId: 1,
         content: this.textArea.value,
-        user: 'ADMIN',
       };
+      fetch(`/api/column/${this.id}`, {
+        method: 'PUT',
+        body: JSON.stringify(body),
+        headers: {
+          'Content-Type': 'application/json',
+          Accept: 'application/json',
+        },
+      })
+        .then((res) => res.json())
+        .then((res) => {
+          if (res.success) {
+            const noteObject = {
+              id: res.data.id,
+              content: res.data.content,
+              user: res.data.user,
+            };
 
-      this.appendNote(noteObject);
-      this.textArea.value = null;
-      this.form.classList.add('disable');
-      this.form.classList.add('hidden');
+            this.appendNote(noteObject);
+            this.textArea.value = null;
+            this.form.classList.add('disable');
+            this.form.classList.add('hidden');
+          }
+        });
     });
   }
 }


### PR DESCRIPTION
>  노트 추가시 DB에도 저장하는 API 적용

## related issue

- #9
- #14

## 설명 (what, why)

column의 노트추가 버튼에 fetch 요청 추가
fetch 후 응답받은 response의 data로 넘어온 새로운 노트로 새 노트 생성
response의 success여부로 노트 추가 결정.

만약 실패인 경우 front view 에 노트 추가되지 않음