### PR TITLE
PR: 추가 - 노트 내용 수정 API

### DIFF
--- a/apis/constants/message.js
+++ b/apis/constants/message.js
@@ -39,4 +39,16 @@ module.exports = {
     TEXT: '데이터의 부족합니다.',
     STATUS_CODE: 500,
   },
+  UPDATE_NOTE_SUCCESS: {
+    TEXT: '노트의 변경이 성공적으로 완료되었습니다.',
+    STATUS_CODE: 200,
+  },
+  UPDATE_NOTE_ERROR: {
+    TEXT: '노트의 변경에 문제가 있습니다',
+    STATUS_CODE: 500,
+  },
+  UPDATE_NOTE_BODY_ERROR: {
+    TEXT: '데이터의 부족합니다.',
+    STATUS_CODE: 500,
+  },
 };

--- a/apis/kanban.js
+++ b/apis/kanban.js
@@ -92,4 +92,48 @@ router.put('/column/:columnId', async (req, res) => {
   res.status(MESSAGE.PUT_NOTE_SUCCESS.STATUS_CODE).json(result);
 });
 
+/**
+ * @api {put} /note/:noteId 해당 노트의 정보를 변경함
+ * @apiName update note content
+ * @apiGroup kanban
+ *
+ * @apiParam {Number} noteId 노트의 id [params]
+ * @apiParam {String} 수정할 노트의 내용 [body]
+ *
+ * @apiSuccess {Boolean} success API 호출 성공 여부
+ * @apiSuccess {String} message 응답 결과 메시지
+ */
+router.put('/note/:noteId', async (req, res) => {
+  const result = {
+    success: false,
+    message: '',
+  };
+  const { noteId } = req.params;
+  const { content } = req.body;
+
+  if (!content) {
+    result.message = MESSAGE.PUT_NOTE_ERROR.TEXT;
+    res.status(MESSAGE.PUT_NOTE_ERROR.STATUS_CODE).json(result);
+    return;
+  }
+
+  const [ret, error] = await safePromise(
+    dao.updateNote(parseInt(noteId), content),
+  );
+  if (error) {
+    result.message = MESSAGE.UPDATE_NOTE_BODY_ERROR.TEXT;
+    res.status(MESSAGE.UPDATE_NOTE_BODY_ERROR.STATUS_CODE).json(result);
+    return;
+  }
+  if (!ret) {
+    result.message = MESSAGE.UPDATE_NOTE_ERROR.TEXT;
+    res.status(MESSAGE.UPDATE_NOTE_ERROR.STATUS_CODE).json(result);
+    return;
+  }
+
+  result.success = true;
+  result.message = MESSAGE.UPDATE_NOTE_SUCCESS.TEXT;
+  res.status(MESSAGE.UPDATE_NOTE_SUCCESS.STATUS_CODE).json(result);
+});
+
 module.exports = router;

--- a/dao/DataAccessObject.js
+++ b/dao/DataAccessObject.js
@@ -11,6 +11,7 @@ const dt = require('../utils/datetime');
 
 const getKanbanData = require('./method/getKanbanData');
 const createNote = require('./method/createNote');
+const updateNote = require('./method/updateNote');
 
 class DataAccessObject {
   constructor(option) {
@@ -121,5 +122,6 @@ class DataAccessObject {
 
 DataAccessObject.prototype.getKanbanData = getKanbanData;
 DataAccessObject.prototype.createNote = createNote;
+DataAccessObject.prototype.updateNote = updateNote;
 
 module.exports = DataAccessObject;

--- a/dao/DataAccessObject.spec.js
+++ b/dao/DataAccessObject.spec.js
@@ -5,6 +5,8 @@ const testPool = require('./constants/poolOptions').test;
 
 const dao = new DataAccessObject(testPool);
 
+let targetNoteId;
+
 test('connect is success.', async () => {
   const success = await dao.isConnectSuccess();
   expect(success).toBe(true);
@@ -33,6 +35,7 @@ test('insert note rows test', async () => {
     content: 'INSERT DAO TEST',
   };
   const note = await dao.createNote(1, newNoteData);
+  targetNoteId = note.id;
 
   expect(note.user).toEqual(newNoteData.user);
   expect(note.content).toEqual(newNoteData.content);
@@ -46,7 +49,8 @@ test('update note test', async () => {
   result = await dao.updateNote(noteId, content);
   expect(result).toEqual(false);
 
-  noteId = 26;
+  // 이전 insert 문에서 생성된 note의 id를 사용함
+  noteId = targetNoteId;
   result = await dao.updateNote(noteId, content);
 
   expect(result).toEqual(true);

--- a/dao/DataAccessObject.spec.js
+++ b/dao/DataAccessObject.spec.js
@@ -38,6 +38,20 @@ test('insert note rows test', async () => {
   expect(note.content).toEqual(newNoteData.content);
 });
 
+test('update note test', async () => {
+  const content = 'update note content';
+  let noteId = -1;
+  let result;
+
+  result = await dao.updateNote(noteId, content);
+  expect(result).toEqual(false);
+
+  noteId = 26;
+  result = await dao.updateNote(noteId, content);
+
+  expect(result).toEqual(true);
+});
+
 afterAll(() => {
   dao.endPool();
 });

--- a/dao/method/createNote.js
+++ b/dao/method/createNote.js
@@ -10,7 +10,7 @@ const INSERT_NOTE = `INSERT INTO NOTE
 VALUES (?, ?, ?, null, ?);
 `;
 
-const UPDATE_LAST_NOTE = `UPDATE NOTE
+const UPDATE_FIRST_NOTE = `UPDATE NOTE
 SET prev_note_id = ?
 WHERE id = ?;`;
 
@@ -55,7 +55,7 @@ module.exports = async function setNote(columnId, noteData) {
     // UPDATE NOTE
     // ?: next_note_id, id
     const [updateRow, updateRowError] = await safePromise(
-      this.executeQuery(connection, UPDATE_LAST_NOTE, [insertId, firstNoteId]),
+      this.executeQuery(connection, UPDATE_FIRST_NOTE, [insertId, firstNoteId]),
     );
 
     if (updateRowError) {

--- a/dao/method/updateNote.js
+++ b/dao/method/updateNote.js
@@ -1,6 +1,6 @@
 const safePromise = require('../../utils/safePromise');
 
-const UPDATE_LAST_NOTE = `UPDATE NOTE
+const UPDATE_NOTE = `UPDATE NOTE
 SET content = ?
 WHERE id = ?;`;
 
@@ -17,7 +17,7 @@ module.exports = async function updateNote(noteId, content) {
     // UPDATE NOTE
     // ?: content, noteId
     const [updateRow, updateRowError] = await safePromise(
-      this.executeQuery(connection, UPDATE_LAST_NOTE, [content, noteId]),
+      this.executeQuery(connection, UPDATE_NOTE, [content, noteId]),
     );
 
     if (updateRowError) {

--- a/dao/method/updateNote.js
+++ b/dao/method/updateNote.js
@@ -1,0 +1,42 @@
+const safePromise = require('../../utils/safePromise');
+
+const UPDATE_LAST_NOTE = `UPDATE NOTE
+SET content = ?
+WHERE id = ?;`;
+
+module.exports = async function updateNote(noteId, content) {
+  const [connection, connectionError] = await safePromise(this.getConnection());
+  if (connectionError) {
+    throw connectionError;
+  }
+  let result = false;
+
+  try {
+    await connection.beginTransaction();
+
+    // UPDATE NOTE
+    // ?: content, noteId
+    const [updateRow, updateRowError] = await safePromise(
+      this.executeQuery(connection, UPDATE_LAST_NOTE, [content, noteId]),
+    );
+
+    if (updateRowError) {
+      throw new Error();
+    }
+
+    // 하나의 note만 update하지 않은경우
+    if (updateRow.affectedRows !== 1) {
+      throw new Error();
+    }
+
+    result = true;
+    await connection.commit();
+  } catch (error) {
+    result = false;
+    connection.rollback();
+  } finally {
+    connection.release();
+  }
+
+  return result;
+};


### PR DESCRIPTION
> 노트의 내용을 수정하는 API 제작

## related issue

- #17
- #14 (변수명 변경)

## 설명 (what, why)

노트의 수정을 수행할 때 오류가 발생하는 경우를 대비해 transaction을 이용함

transaction의 경우 CRUD에서 R을 제외한 CUD에서 사용하려함.
이는 데이터의 변경 시 문제가 생겼을 때 유연하게 대처하기 위함

