### PR TITLE
PR: 추가 - 노트 삭제 API

### DIFF
--- a/apis/constants/message.js
+++ b/apis/constants/message.js
@@ -51,4 +51,12 @@ module.exports = {
     TEXT: '데이터의 부족합니다.',
     STATUS_CODE: 500,
   },
+  DELETE_NOTE_SUCCESS: {
+    TEXT: '노트의 삭제가 성공적으로 이루어졌습니다.',
+    STATUS_CODE: 200,
+  },
+  DELETE_NOTE_ERROR: {
+    TEXT: '노트를 삭제하지 못했습니다.',
+    STATUS_CODE: 500,
+  },
 };

--- a/apis/kanban.js
+++ b/apis/kanban.js
@@ -136,4 +136,34 @@ router.put('/note/:noteId', async (req, res) => {
   res.status(MESSAGE.UPDATE_NOTE_SUCCESS.STATUS_CODE).json(result);
 });
 
+/**
+ * @api {delete} /note/:noteId 해당 노트를 삭제함
+ * @apiName delete note
+ * @apiGroup kanban
+ *
+ * @apiParam {Number} noteId 노트의 id [params]
+ *
+ * @apiSuccess {Boolean} success API 호출 성공 여부
+ * @apiSuccess {String} message 응답 결과 메시지
+ */
+router.delete('/note/:noteId', async (req, res) => {
+  const result = {
+    success: false,
+    message: '',
+  };
+  const { noteId } = req.params;
+
+  const [ret, error] = await safePromise(dao.deleteNote(parseInt(noteId)));
+
+  if (error || !ret) {
+    result.message = MESSAGE.DELETE_NOTE_ERROR.TEXT;
+    res.status(MESSAGE.DELETE_NOTE_ERROR.STATUS_CODE).json(result);
+    return;
+  }
+
+  result.success = true;
+  result.message = MESSAGE.DELETE_NOTE_SUCCESS.TEXT;
+  res.status(MESSAGE.DELETE_NOTE_SUCCESS.STATUS_CODE).json(result);
+});
+
 module.exports = router;

--- a/dao/DataAccessObject.js
+++ b/dao/DataAccessObject.js
@@ -12,6 +12,7 @@ const dt = require('../utils/datetime');
 const getKanbanData = require('./method/getKanbanData');
 const createNote = require('./method/createNote');
 const updateNote = require('./method/updateNote');
+const deleteNote = require('./method/deleteNote');
 
 class DataAccessObject {
   constructor(option) {
@@ -123,5 +124,6 @@ class DataAccessObject {
 DataAccessObject.prototype.getKanbanData = getKanbanData;
 DataAccessObject.prototype.createNote = createNote;
 DataAccessObject.prototype.updateNote = updateNote;
+DataAccessObject.prototype.deleteNote = deleteNote;
 
 module.exports = DataAccessObject;

--- a/dao/DataAccessObject.spec.js
+++ b/dao/DataAccessObject.spec.js
@@ -56,6 +56,14 @@ test('update note test', async () => {
   expect(result).toEqual(true);
 });
 
+test('delete note test', async () => {
+  // 이전 insert 문에서 생성된 note의 id를 사용함
+  const noteId = targetNoteId;
+  const result = await dao.deleteNote(noteId);
+
+  expect(result).toEqual(true);
+});
+
 afterAll(() => {
   dao.endPool();
 });

--- a/dao/method/deleteNote.js
+++ b/dao/method/deleteNote.js
@@ -1,0 +1,90 @@
+const safePromise = require('../../utils/safePromise');
+
+const READ_NOTE_LINK = `SELECT prev_note_id, next_note_id FROM NOTE
+WHERE id = ?;`;
+
+const DELETE_NOTE = `DELETE FROM NOTE
+WHERE id = ?;`;
+
+const UPDATE_NEXT_NOTE = `UPDATE NOTE
+SET next_note_id = ?
+WHERE id = ?;`;
+
+const UPDATE_PREV_NOTE = `UPDATE NOTE
+SET prev_note_id = ?
+WHERE id = ?;`;
+
+module.exports = async function deleteNote(noteId) {
+  const [connection, connectionError] = await safePromise(this.getConnection());
+  if (connectionError) {
+    throw connectionError;
+  }
+  let result = false;
+
+  try {
+    await connection.beginTransaction();
+    let rows, error;
+
+    // READ NOTE LINK
+    // ?: noteId
+    [rows, error] = await safePromise(
+      this.executeQuery(connection, READ_NOTE_LINK, [noteId]),
+    );
+
+    if (error) {
+      throw new Error();
+    }
+    if (rows.length !== 1) {
+      throw new Error();
+    }
+
+    const { prev_note_id, next_note_id } = rows[0];
+
+    if (prev_note_id !== null) {
+      // UPDATE_NEXT_NOTE
+      // ?: next_note_id, NOTE.id
+      [rows, error] = await safePromise(
+        this.executeQuery(connection, UPDATE_NEXT_NOTE, [
+          next_note_id,
+          prev_note_id,
+        ]),
+      );
+    }
+
+    if (next_note_id !== null) {
+      // UPDATE_NEXT_NOTE
+      // ?: prev_note_id, NOTE.id
+      [rows, error] = await safePromise(
+        this.executeQuery(connection, UPDATE_PREV_NOTE, [
+          prev_note_id,
+          next_note_id,
+        ]),
+      );
+    }
+
+    // DELETE NOTE
+    // ?: noteId
+    [rows, error] = await safePromise(
+      this.executeQuery(connection, DELETE_NOTE, [noteId]),
+    );
+
+    if (error) {
+      throw new Error();
+    }
+
+    // 하나의 note만 update하지 않은경우
+    if (rows.affectedRows !== 1) {
+      throw new Error();
+    }
+
+    result = true;
+    await connection.commit();
+  } catch (error) {
+    result = false;
+    connection.rollback();
+  } finally {
+    connection.release();
+  }
+
+  return result;
+};


### PR DESCRIPTION
> 노트를 삭제하는 API 추가

## related issue

- #15 

## 설명 (what, why)

연결 구조를 갱신해야 하기 때문에 순서는 다음과 같음

- 삭제하려는 노트의 연결 구조를 찾아옴
- prev 연결 구조 갱신
- next 연결 구조 갱신
- 해당 노트 삭제

노트를 삭제하는 메소드에 대한 테스트 코드를 추가함. 이전 테스트 코드에서 생성한 노트를 삭제하도록 구현함