### PR TITLE
PR: 추가 - 노트 이동 API

### DIFF
--- a/apis/constants/message.js
+++ b/apis/constants/message.js
@@ -48,7 +48,7 @@ module.exports = {
     STATUS_CODE: 500,
   },
   UPDATE_NOTE_BODY_ERROR: {
-    TEXT: '데이터의 부족합니다.',
+    TEXT: '데이터가 부족합니다.',
     STATUS_CODE: 500,
   },
   DELETE_NOTE_SUCCESS: {
@@ -57,6 +57,18 @@ module.exports = {
   },
   DELETE_NOTE_ERROR: {
     TEXT: '노트를 삭제하지 못했습니다.',
+    STATUS_CODE: 500,
+  },
+  MOVE_NOTE_SUCCESS: {
+    TEXT: '노트의 이동이 성공적으로 이루어졌습니다.',
+    STATUS_CODE: 200,
+  },
+  MOVE_NOTE_BODY_ERROR: {
+    TEXT: '데이터가 유효하지 않습니다.',
+    STATUS_CODE: 500,
+  },
+  MOVE_NOTE_ERROR: {
+    TEXT: '노트를 이동하지 못했습니다.',
     STATUS_CODE: 500,
   },
 };

--- a/apis/kanban.js
+++ b/apis/kanban.js
@@ -166,4 +166,49 @@ router.delete('/note/:noteId', async (req, res) => {
   res.status(MESSAGE.DELETE_NOTE_SUCCESS.STATUS_CODE).json(result);
 });
 
+/**
+ * @api {patch} /note/move/:noteId 해당 노트 이동시킴
+ * @apiName move note
+ * @apiGroup kanban
+ *
+ * @apiParam {Number} noteId 노트의 id [params]
+ * @apiParam {Number} beforeNoteId 노트의 id [body]
+ * @apiParam {Number} afterNoteId 노트의 id [body]
+ *
+ * @apiSuccess {Boolean} success API 호출 성공 여부
+ * @apiSuccess {String} message 응답 결과 메시지
+ */
+router.patch('/note/move/:noteId', async (req, res) => {
+  const result = {
+    success: false,
+    message: '',
+  };
+
+  const { noteId } = req.params;
+  let { beforeNoteId, afterNoteId } = req.body;
+
+  beforeNoteId = isNaN(parseInt(beforeNoteId)) ? null : parseInt(beforeNoteId);
+  afterNoteId = isNaN(parseInt(afterNoteId)) ? null : parseInt(afterNoteId);
+
+  if (!beforeNoteId && !afterNoteId) {
+    result.message = MESSAGE.MOVE_NOTE_BODY_ERROR.TEXT;
+    res.status(MESSAGE.MOVE_NOTE_BODY_ERROR.STATUS_CODE).json(result);
+    return;
+  }
+
+  const [ret, error] = await safePromise(
+    dao.moveNote(parseInt(noteId), beforeNoteId, afterNoteId),
+  );
+
+  if (error || !ret) {
+    result.message = MESSAGE.MOVE_NOTE_ERROR.TEXT;
+    res.status(MESSAGE.MOVE_NOTE_ERROR.STATUS_CODE).json(result);
+    return;
+  }
+
+  result.success = true;
+  result.message = MESSAGE.MOVE_NOTE_SUCCESS.TEXT;
+  res.status(MESSAGE.MOVE_NOTE_SUCCESS.STATUS_CODE).json(result);
+});
+
 module.exports = router;

--- a/dao/DataAccessObject.js
+++ b/dao/DataAccessObject.js
@@ -13,6 +13,7 @@ const getKanbanData = require('./method/getKanbanData');
 const createNote = require('./method/createNote');
 const updateNote = require('./method/updateNote');
 const deleteNote = require('./method/deleteNote');
+const moveNote = require('./method/moveNote');
 
 class DataAccessObject {
   constructor(option) {
@@ -125,5 +126,6 @@ DataAccessObject.prototype.getKanbanData = getKanbanData;
 DataAccessObject.prototype.createNote = createNote;
 DataAccessObject.prototype.updateNote = updateNote;
 DataAccessObject.prototype.deleteNote = deleteNote;
+DataAccessObject.prototype.moveNote = moveNote;
 
 module.exports = DataAccessObject;

--- a/dao/DataAccessObject.spec.js
+++ b/dao/DataAccessObject.spec.js
@@ -64,6 +64,27 @@ test('delete note test', async () => {
   expect(result).toEqual(true);
 });
 
+test('move note test', async () => {
+  // 이전 insert 문에서 생성된 note의 id를 사용함
+  const noteId = 1;
+  let result;
+
+  result = await dao.moveNote(noteId, 3, 4);
+  expect(result).toEqual(true);
+
+  result = await dao.moveNote(noteId, null, 3);
+  expect(result).toEqual(true);
+
+  result = await dao.moveNote(noteId, 7, null);
+  expect(result).toEqual(true);
+
+  result = await dao.moveNote(noteId, null, 33);
+  expect(result).toEqual(true);
+
+  result = await dao.moveNote(noteId, null, null);
+  expect(result).toEqual(false);
+});
+
 afterAll(() => {
   dao.endPool();
 });

--- a/dao/method/moveNote.js
+++ b/dao/method/moveNote.js
@@ -1,0 +1,113 @@
+const safePromise = require('../../utils/safePromise');
+
+const READ_NOTE_LINK = `SELECT prev_note_id, next_note_id FROM NOTE
+WHERE id = ?;`;
+
+const UPDATE_NEXT_NOTE = `UPDATE NOTE
+SET next_note_id = ?
+WHERE id = ?;`;
+
+const UPDATE_PREV_NOTE = `UPDATE NOTE
+SET prev_note_id = ?
+WHERE id = ?;`;
+
+const UPDATE_LINK = `UPDATE NOTE
+SET prev_note_id = ?, next_note_id = ?
+WHERE id = ?;`;
+
+module.exports = async function moveNote(noteId, beforeNoteId, afterNoteId) {
+  const [connection, connectionError] = await safePromise(this.getConnection());
+  if (connectionError) {
+    throw connectionError;
+  }
+  let result = false;
+
+  try {
+    await connection.beginTransaction();
+    let rows, error;
+
+    /**
+     * 이전 노트와의 연결 관계를 끊어줌
+     */
+    // READ NOTE LINK
+    // ?: noteId
+    [rows, error] = await safePromise(
+      this.executeQuery(connection, READ_NOTE_LINK, [noteId]),
+    );
+
+    if (error || rows.length !== 1) {
+      throw new Error();
+    }
+
+    const { prev_note_id, next_note_id } = rows[0];
+
+    if (prev_note_id !== null) {
+      // UPDATE_NEXT_NOTE
+      // ?: next_note_id, NOTE.id
+      error = await safePromise(
+        this.executeQuery(connection, UPDATE_NEXT_NOTE, [
+          next_note_id,
+          prev_note_id,
+        ]),
+      )[1];
+    }
+
+    if (next_note_id !== null) {
+      // UPDATE_NEXT_NOTE
+      // ?: prev_note_id, NOTE.id
+      error = await safePromise(
+        this.executeQuery(connection, UPDATE_PREV_NOTE, [
+          prev_note_id,
+          next_note_id,
+        ]),
+      )[0];
+    }
+
+    /**
+     * 새 위치에 연관되어있는 노트들의 연결관계 갱신
+     */
+    if (!beforeNoteId && !afterNoteId) {
+      throw new Error();
+    }
+
+    if (beforeNoteId) {
+      // UPDATE_NEXT_NOTE
+      // ?: next_note_id, NOTE.id
+      error = await safePromise(
+        this.executeQuery(connection, UPDATE_NEXT_NOTE, [noteId, beforeNoteId]),
+      )[1];
+    }
+    if (afterNoteId) {
+      // UPDATE_PREV_NOTE
+      // ?: next_note_id, NOTE.id
+      error = await safePromise(
+        this.executeQuery(connection, UPDATE_PREV_NOTE, [noteId, afterNoteId]),
+      )[1];
+    }
+
+    [rows, error] = await safePromise(
+      // UPDATE_LINK
+      // ?: prev_note_id, next_note_id, noteId
+      this.executeQuery(connection, UPDATE_LINK, [
+        beforeNoteId,
+        afterNoteId,
+        noteId,
+      ]),
+    );
+
+    // 하나의 note만 update하지 않은경우
+    if (error || rows.affectedRows !== 1) {
+      throw new Error();
+    }
+
+    result = true;
+    await connection.commit();
+  } catch (error) {
+    result = false;
+    connection.rollback();
+  } finally {
+    connection.release();
+  }
+
+  return result;
+};

--- a/dao/method/moveNote.js
+++ b/dao/method/moveNote.js
@@ -1,5 +1,8 @@
 const safePromise = require('../../utils/safePromise');
 
+const READ_LINK_NOTES = `SELECT id, prev_note_id, next_note_id FROM NOTE
+WHERE id = ? OR id = ?`;
+
 const READ_NOTE_LINK = `SELECT prev_note_id, next_note_id FROM NOTE
 WHERE id = ?;`;
 
@@ -15,6 +18,40 @@ const UPDATE_LINK = `UPDATE NOTE
 SET prev_note_id = ?, next_note_id = ?
 WHERE id = ?;`;
 
+/**
+ * 입력받은 인자의 유효성 검사
+ * @param {*} connection  mysql2 connection 객체
+ * @param {*} query       query를 실행하는 함수
+ * @param {*} beforeId    연결 구조에서 앞에 위치한 노트
+ * @param {*} afterId     연결 구조에서 뒤에 위치한 노트
+ */
+async function checkCorrectLink(connection, query, beforeId, afterId) {
+  if (!beforeId || !afterId) {
+    return true;
+  }
+
+  // READ LINK NOTES
+  // prev_note_id, next_note_id
+  const [rows, error] = await safePromise(
+    query(connection, READ_LINK_NOTES, [beforeId, afterId]),
+  );
+  if (error || rows.length !== 2) {
+    return false;
+  }
+
+  const isValidLink =
+    (rows[0].next_note_id === rows[1].id &&
+      rows[1].prev_note_id === rows[0].id) ||
+    (rows[0].prev_note_id === rows[1].id &&
+      rows[1].next_note_id === rows[0].id);
+
+  // 연결 관계가 유효한지 check
+  if (isValidLink) {
+    return true;
+  }
+  return false;
+}
+
 module.exports = async function moveNote(noteId, beforeNoteId, afterNoteId) {
   const [connection, connectionError] = await safePromise(this.getConnection());
   if (connectionError) {
@@ -25,6 +62,16 @@ module.exports = async function moveNote(noteId, beforeNoteId, afterNoteId) {
   try {
     await connection.beginTransaction();
     let rows, error;
+
+    const isCorrectLink = await checkCorrectLink(
+      connection,
+      this.executeQuery,
+      beforeNoteId,
+      afterNoteId,
+    );
+    if (!isCorrectLink) {
+      throw new Error();
+    }
 
     /**
      * 이전 노트와의 연결 관계를 끊어줌
@@ -95,7 +142,7 @@ module.exports = async function moveNote(noteId, beforeNoteId, afterNoteId) {
       ]),
     );
 
-    // 하나의 note만 update하지 않은경우
+    // 에러가 발생했거나, 하나의 note만 update하지 않은경우
     if (error || rows.affectedRows !== 1) {
       throw new Error();
     }


### PR DESCRIPTION
> 노트의 연결관계를 변경시키는 API 추가

## related issue

- #53 

## 설명 (what, why)

현재 노트의 id와 이동할 위치의 앞, 뒤 노트의 id를 인자로 받아 순서를 바꿔주는 method 작성

1. 이전 노트와의 연결 관계를 끊어줌
2. 새 위치에 연관되어있는 노트들의 연결관계 갱신

노트 이동 시, 도착한 위치의 연결 관계가 유효한지 검사하는 safe guard 추가

테스트 항목
- 맨 끝으로 이동이 제대로 되는지
- 맨 처음으로 이동이 제대로 되는지
- 유효하지 않은 메소드 호출