### PR TITLE
PR: 추가 - 노트 수정, 삭제 이벤트 적용

### DIFF
--- a/src/javascripts/Components/Note.js
+++ b/src/javascripts/Components/Note.js
@@ -41,8 +41,14 @@ export default class Note extends Element {
     return section;
   }
 
+  setContent(text) {
+    this.content = text;
+    this.element.querySelector('.content').innerText = text;
+  }
+
   setElement() {
     const wrapper = this.getWrapper();
+    wrapper.className = 'note';
 
     const button = document.createElement('button');
     button.className = 'close';


### PR DESCRIPTION
> 노트 수정, 삭제 이벤트 적용

## related issue

- #10 
- #11

## 설명 (what, why)

- 콜백 함수에서 이를 소유한 컬럼으로 접근하기 위해, 콜백 함수에 바인딩 걸어줌
- 노트 내용 수정될 때, 컬럼 내 데이터와 노트의 돔 데이터 함께 수정됨
(이전 내용과 동일하면, 수정 이벤트는 일어나지 않음)
- 노트 삭제 이벤트 처리