### PR TITLE
PR: !HOTFIX 노트 이동 dao method

### DIFF
--- a/dao/method/functions/checkCorrectLink.js
+++ b/dao/method/functions/checkCorrectLink.js
@@ -1,0 +1,68 @@
+const safePromise = require('../../../utils/safePromise');
+
+const READ_LINK_NOTES = `SELECT id, prev_note_id, next_note_id, column_id FROM NOTE
+WHERE id = ? OR id = ?`;
+
+function checkLink(firstNote, secondNote) {
+  return (
+    firstNote.next_note_id === secondNote.id &&
+    secondNote.prev_note_id === firstNote.id
+  );
+}
+
+/**
+ * 입력받은 인자의 유효성 검사
+ * @param {Object} connection  mysql2 connection 객체
+ * @param {Function} query     query를 실행하는 함수
+ * @param {Number} beforeId    연결 구조에서 앞에 위치한 노트
+ * @param {Number} afterId     연결 구조에서 뒤에 위치한 노트
+ * @param {Number} columnId    검사 하고자 하는 column의 id
+ */
+module.exports = async function checkCorrectLink(
+  connection,
+  query,
+  beforeId,
+  afterId,
+  columnId,
+) {
+  if (!beforeId || !afterId) {
+    return true;
+  }
+  // READ LINK NOTES
+  // prev_note_id, next_note_id
+  const [rows, error] = await safePromise(
+    query(connection, READ_LINK_NOTES, [beforeId, afterId]),
+  );
+
+  if (error || rows.length === 0 || rows.length > 2) {
+    throw new Error();
+  }
+
+  const firstNote = {
+    id: rows[0].id,
+    next_note_id: rows[0].next_note_id,
+    prev_note_id: rows[0].prev_note_id,
+    column_id: rows[0].column_id,
+  };
+
+  if (firstNote.column_id !== columnId) {
+    throw new Error();
+  }
+
+  const secondNote = {
+    id: rows[1].id,
+    next_note_id: rows[1].next_note_id,
+    prev_note_id: rows[1].prev_note_id,
+    column_id: rows[1].column_id,
+  };
+
+  // 연결 관계가 유효한지 check
+  const isValid =
+    (checkLink(firstNote, secondNote) || checkLink(secondNote, firstNote)) &&
+    firstNote.column_id === columnId &&
+    secondNote.column_id === columnId;
+
+  if (!isValid) {
+    throw new Error();
+  }
+};

--- a/dao/method/functions/pickNoteLink.js
+++ b/dao/method/functions/pickNoteLink.js
@@ -1,0 +1,47 @@
+const safePromise = require('../../../utils/safePromise');
+
+const READ_NOTE_LINK = `SELECT prev_note_id, next_note_id FROM NOTE
+WHERE id = ?;`;
+
+const UPDATE_NEXT_NOTE = `UPDATE NOTE
+SET next_note_id = ?
+WHERE id = ?;`;
+
+const UPDATE_PREV_NOTE = `UPDATE NOTE
+SET prev_note_id = ?
+WHERE id = ?;`;
+
+/**
+ * 해당 노트와 연결된 노트들의 연결관계를 갱신해줌
+ * @param {Object} connection  mysql2 connection 객체
+ * @param {Function} query     query를 실행하는 함수
+ * @param {Number} noteId      연결을 갱신한 노트의 id
+ */
+module.exports = async function pickNoteLink(connection, query, noteId) {
+  // READ NOTE LINK
+  // ?: noteId
+  let [rows, error] = await safePromise(
+    query(connection, READ_NOTE_LINK, [noteId]),
+  );
+  if (error || rows.length !== 1) {
+    throw new Error();
+  }
+
+  const { prev_note_id, next_note_id } = rows[0];
+
+  if (prev_note_id !== null) {
+    // UPDATE_NEXT_NOTE
+    // ?: next_note_id, NOTE.id
+    error = await safePromise(
+      query(connection, UPDATE_NEXT_NOTE, [next_note_id, prev_note_id]),
+    )[1];
+  }
+
+  if (next_note_id !== null) {
+    // UPDATE_NEXT_NOTE
+    // ?: prev_note_id, NOTE.id
+    error = await safePromise(
+      query(connection, UPDATE_PREV_NOTE, [prev_note_id, next_note_id]),
+    )[0];
+  }
+};

--- a/dao/method/functions/pushNoteToEmptyColumn.js
+++ b/dao/method/functions/pushNoteToEmptyColumn.js
@@ -1,0 +1,38 @@
+const safePromise = require('../../../utils/safePromise');
+
+const READ_NOTE_OF_COLUMN = `
+SELECT id FROM NOTE
+WHERE column_id = ?`;
+
+const UPDATE_NOTE_COLUMN = `UPDATE NOTE
+SET prev_note_id = null, next_note_id = null, column_id = ?
+WHERE id = ?;`;
+
+/**
+ * 빈 컬럼에 새로운 노트를 추가함
+ * @param {Object} connection  mysql2 connection 객체
+ * @param {Function} query     query를 실행하는 함수
+ * @param {Number} columnId    연결을 갱신할 컬럼의 id
+ * @param {Number} noteId      연결을 갱신한 노트의 id
+ */
+module.exports = async function pushNoteToEmptyColumn(
+  connection,
+  query,
+  columnId,
+  noteId,
+) {
+  // READ_NOTE_OF_COLUMN
+  // ?: column_id
+  const [rows, error] = await safePromise(
+    query(connection, READ_NOTE_OF_COLUMN, [columnId]),
+  );
+
+  if (rows.length !== 0 || error) {
+    throw new Error();
+  }
+
+  // 새로운 column에 노트를 추가
+  // UPDATE NOTE COLUMN
+  // ?: column_id, noteId
+  await safePromise(query(connection, UPDATE_NOTE_COLUMN, [columnId, noteId]));
+};

--- a/dao/method/functions/updateNoteLink.js
+++ b/dao/method/functions/updateNoteLink.js
@@ -1,0 +1,61 @@
+const safePromise = require('../../../utils/safePromise');
+
+const UPDATE_NEXT_NOTE = `UPDATE NOTE
+SET next_note_id = ?
+WHERE id = ?;`;
+
+const UPDATE_PREV_NOTE = `UPDATE NOTE
+SET prev_note_id = ?
+WHERE id = ?;`;
+
+const UPDATE_LINK = `UPDATE NOTE
+SET prev_note_id = ?, next_note_id = ?, column_id = ?
+WHERE id = ?;`;
+
+/**
+ * 노트의 연결 관계를 update함
+ * @param {Object} connection  mysql2 connection 객체
+ * @param {Function} query     query를 실행하는 함수
+ * @param {Number} columnId    연결을 갱신할 컬럼의 id
+ * @param {Number} noteId      연결을 갱신한 노트의 id
+ */
+module.exports = async function updateNoteLink(
+  connection,
+  query,
+  noteId,
+  columnId,
+  beforeNoteId,
+  afterNoteId,
+) {
+  if (beforeNoteId) {
+    // UPDATE_NEXT_NOTE
+    // ?: next_note_id, NOTE.id
+    await safePromise(
+      query(connection, UPDATE_NEXT_NOTE, [noteId, beforeNoteId]),
+    );
+  }
+
+  if (afterNoteId) {
+    // UPDATE_PREV_NOTE
+    // ?: next_note_id, NOTE.id
+    await safePromise(
+      query(connection, UPDATE_PREV_NOTE, [noteId, afterNoteId]),
+    );
+  }
+
+  const [rows, error] = await safePromise(
+    // UPDATE_LINK
+    // ?: prev_note_id, next_note_id, column_id, noteId
+    query(connection, UPDATE_LINK, [
+      beforeNoteId,
+      afterNoteId,
+      columnId,
+      noteId,
+    ]),
+  );
+
+  // 에러가 발생했거나, 하나의 note만 update하지 않은경우
+  if (error || rows.affectedRows !== 1) {
+    throw new Error();
+  }
+};

--- a/dao/method/moveNote.js
+++ b/dao/method/moveNote.js
@@ -103,18 +103,6 @@ module.exports = async function moveNote(
     await connection.beginTransaction();
     let rows, error;
 
-    const isCorrectLink = await checkCorrectLink(
-      connection,
-      this.executeQuery,
-      beforeNoteId,
-      afterNoteId,
-      columnId,
-    );
-
-    if (!isCorrectLink) {
-      throw new Error();
-    }
-
     /**
      * 이전 노트와의 연결 관계를 끊어줌
      */
@@ -150,6 +138,18 @@ module.exports = async function moveNote(
           next_note_id,
         ]),
       )[0];
+    }
+
+    const isCorrectLink = await checkCorrectLink(
+      connection,
+      this.executeQuery,
+      beforeNoteId,
+      afterNoteId,
+      columnId,
+    );
+
+    if (!isCorrectLink) {
+      throw new Error();
     }
 
     /**

--- a/dao/method/moveNote.js
+++ b/dao/method/moveNote.js
@@ -1,129 +1,8 @@
 const safePromise = require('../../utils/safePromise');
-
-const READ_LINK_NOTES = `SELECT id, prev_note_id, next_note_id, column_id FROM NOTE
-WHERE id = ? OR id = ?`;
-
-const READ_NOTE_LINK = `SELECT prev_note_id, next_note_id FROM NOTE
-WHERE id = ?;`;
-
-const UPDATE_NEXT_NOTE = `UPDATE NOTE
-SET next_note_id = ?
-WHERE id = ?;`;
-
-const UPDATE_PREV_NOTE = `UPDATE NOTE
-SET prev_note_id = ?
-WHERE id = ?;`;
-
-const UPDATE_LINK = `UPDATE NOTE
-SET prev_note_id = ?, next_note_id = ?, column_id = ?
-WHERE id = ?;`;
-
-const READ_NOTE_OF_COLUMN = `
-SELECT id FROM NOTE
-WHERE column_id = ?`;
-
-const UPDATE_NOTE_COLUMN = `UPDATE NOTE
-SET prev_note_id = null, next_note_id = null, column_id = ?
-WHERE id = ?;`;
-
-function checkLink(firstNote, secondNote) {
-  return (
-    firstNote.next_note_id === secondNote.id &&
-    secondNote.prev_note_id === firstNote.id
-  );
-}
-
-/**
- * 입력받은 인자의 유효성 검사
- * @param {Object} connection  mysql2 connection 객체
- * @param {Function} query     query를 실행하는 함수
- * @param {Number} beforeId    연결 구조에서 앞에 위치한 노트
- * @param {Number} afterId     연결 구조에서 뒤에 위치한 노트
- * @param {Number} columnId    검사 하고자 하는 column의 id
- */
-async function checkCorrectLink(
-  connection,
-  query,
-  beforeId,
-  afterId,
-  columnId,
-) {
-  if (!beforeId || !afterId) {
-    return true;
-  }
-  // READ LINK NOTES
-  // prev_note_id, next_note_id
-  const [rows, error] = await safePromise(
-    query(connection, READ_LINK_NOTES, [beforeId, afterId]),
-  );
-
-  if (error || rows.length === 0 || rows.length > 2) {
-    throw new Error();
-  }
-
-  const firstNote = {
-    id: rows[0].id,
-    next_note_id: rows[0].next_note_id,
-    prev_note_id: rows[0].prev_note_id,
-    column_id: rows[0].column_id,
-  };
-
-  if (firstNote.column_id !== columnId) {
-    throw new Error();
-  }
-
-  const secondNote = {
-    id: rows[1].id,
-    next_note_id: rows[1].next_note_id,
-    prev_note_id: rows[1].prev_note_id,
-    column_id: rows[1].column_id,
-  };
-
-  // 연결 관계가 유효한지 check
-  const isValid =
-    (checkLink(firstNote, secondNote) || checkLink(secondNote, firstNote)) &&
-    firstNote.column_id === columnId &&
-    secondNote.column_id === columnId;
-
-  if (!isValid) {
-    throw new Error();
-  }
-}
-
-/**
- * 해당 노트와 연결된 노트들의 연결관계를 갱신해줌
- * @param {Object} connection  mysql2 connection 객체
- * @param {Function} query     query를 실행하는 함수
- * @param {Number} noteId      연결을 갱신한 노트의 id
- */
-async function pickNoteLink(connection, query, noteId) {
-  // READ NOTE LINK
-  // ?: noteId
-  let [rows, error] = await safePromise(
-    query(connection, READ_NOTE_LINK, [noteId]),
-  );
-  if (error || rows.length !== 1) {
-    throw new Error();
-  }
-
-  const { prev_note_id, next_note_id } = rows[0];
-
-  if (prev_note_id !== null) {
-    // UPDATE_NEXT_NOTE
-    // ?: next_note_id, NOTE.id
-    error = await safePromise(
-      query(connection, UPDATE_NEXT_NOTE, [next_note_id, prev_note_id]),
-    )[1];
-  }
-
-  if (next_note_id !== null) {
-    // UPDATE_NEXT_NOTE
-    // ?: prev_note_id, NOTE.id
-    error = await safePromise(
-      query(connection, UPDATE_PREV_NOTE, [prev_note_id, next_note_id]),
-    )[0];
-  }
-}
+const checkCorrectLink = require('./functions/checkCorrectLink');
+const pickNoteLink = require('./functions/pickNoteLink');
+const pushNoteToEmptyColumn = require('./functions/pushNoteToEmptyColumn');
+const updateNoteLink = require('./functions/updateNoteLink');
 
 module.exports = async function moveNote(
   noteId,
@@ -139,12 +18,11 @@ module.exports = async function moveNote(
 
   try {
     await connection.beginTransaction();
-    let rows, error;
 
-    // 이전 노트와 연결된 노트들의 연결 관계를 끊어줌
+    // 1. 이전 노트와 연결된 노트들의 연결 관계를 끊어줌
     await pickNoteLink(connection, this.executeQuery, noteId);
 
-    // 이동할 위치의 연결 관계가 유효한지 확인
+    // 2. 이동할 위치의 연결 관계가 유효한지 확인
     await checkCorrectLink(
       connection,
       this.executeQuery,
@@ -153,64 +31,25 @@ module.exports = async function moveNote(
       columnId,
     );
 
-    /**
-     * 새 위치에 연관되어있는 노트들의 연결관계 갱신
-     */
+    // 3. 새 위치에 연관되어있는 노트들의 연결관계 갱신
     if (!beforeNoteId && !afterNoteId) {
-      // 새로운 column에 추가하는 것인지 확인
-      // UPDATE_LINK
-      // ?: prev_note_id, next_note_id, column_id, noteId
-      [rows, error] = await safePromise(
-        this.executeQuery(connection, READ_NOTE_OF_COLUMN, [columnId]),
-      );
-
-      if (rows.length !== 0) {
-        throw new Error();
-      }
-
-      // 새로운 column에 노트를 추가
-      // UPDATE NOTE COLUMN
-      // ?: column_id, noteId
-      [rows, error] = await safePromise(
-        this.executeQuery(connection, UPDATE_NOTE_COLUMN, [columnId, noteId]),
+      // 빈 column에 새로운 노트 추가
+      await pushNoteToEmptyColumn(
+        connection,
+        this.executeQuery,
+        columnId,
+        noteId,
       );
     } else {
-      if (beforeNoteId) {
-        // UPDATE_NEXT_NOTE
-        // ?: next_note_id, NOTE.id
-        error = await safePromise(
-          this.executeQuery(connection, UPDATE_NEXT_NOTE, [
-            noteId,
-            beforeNoteId,
-          ]),
-        )[1];
-      }
-      if (afterNoteId) {
-        // UPDATE_PREV_NOTE
-        // ?: next_note_id, NOTE.id
-        error = await safePromise(
-          this.executeQuery(connection, UPDATE_PREV_NOTE, [
-            noteId,
-            afterNoteId,
-          ]),
-        )[1];
-      }
-
-      [rows, error] = await safePromise(
-        // UPDATE_LINK
-        // ?: prev_note_id, next_note_id, column_id, noteId
-        this.executeQuery(connection, UPDATE_LINK, [
-          beforeNoteId,
-          afterNoteId,
-          columnId,
-          noteId,
-        ]),
+      // 연결 관계 갱신
+      await updateNoteLink(
+        connection,
+        this.executeQuery,
+        noteId,
+        columnId,
+        beforeNoteId,
+        afterNoteId,
       );
-
-      // 에러가 발생했거나, 하나의 note만 update하지 않은경우
-      if (error || rows.affectedRows !== 1) {
-        throw new Error();
-      }
     }
 
     result = true;

--- a/dao/method/moveNote.js
+++ b/dao/method/moveNote.js
@@ -36,7 +36,7 @@ function checkLink(firstNote, secondNote) {
 /**
  * 입력받은 인자의 유효성 검사
  * @param {Object} connection  mysql2 connection 객체
- * @param {Function} query       query를 실행하는 함수
+ * @param {Function} query     query를 실행하는 함수
  * @param {Number} beforeId    연결 구조에서 앞에 위치한 노트
  * @param {Number} afterId     연결 구조에서 뒤에 위치한 노트
  * @param {Number} columnId    검사 하고자 하는 column의 id
@@ -58,7 +58,7 @@ async function checkCorrectLink(
   );
 
   if (error || rows.length === 0 || rows.length > 2) {
-    return false;
+    throw new Error();
   }
 
   const firstNote = {
@@ -69,7 +69,7 @@ async function checkCorrectLink(
   };
 
   if (firstNote.column_id !== columnId) {
-    return false;
+    throw new Error();
   }
 
   const secondNote = {
@@ -80,11 +80,49 @@ async function checkCorrectLink(
   };
 
   // 연결 관계가 유효한지 check
-  return (
+  const isValid =
     (checkLink(firstNote, secondNote) || checkLink(secondNote, firstNote)) &&
     firstNote.column_id === columnId &&
-    secondNote.column_id === columnId
+    secondNote.column_id === columnId;
+
+  if (!isValid) {
+    throw new Error();
+  }
+}
+
+/**
+ * 해당 노트와 연결된 노트들의 연결관계를 갱신해줌
+ * @param {Object} connection  mysql2 connection 객체
+ * @param {Function} query     query를 실행하는 함수
+ * @param {Number} noteId      연결을 갱신한 노트의 id
+ */
+async function pickNoteLink(connection, query, noteId) {
+  // READ NOTE LINK
+  // ?: noteId
+  let [rows, error] = await safePromise(
+    query(connection, READ_NOTE_LINK, [noteId]),
   );
+  if (error || rows.length !== 1) {
+    throw new Error();
+  }
+
+  const { prev_note_id, next_note_id } = rows[0];
+
+  if (prev_note_id !== null) {
+    // UPDATE_NEXT_NOTE
+    // ?: next_note_id, NOTE.id
+    error = await safePromise(
+      query(connection, UPDATE_NEXT_NOTE, [next_note_id, prev_note_id]),
+    )[1];
+  }
+
+  if (next_note_id !== null) {
+    // UPDATE_NEXT_NOTE
+    // ?: prev_note_id, NOTE.id
+    error = await safePromise(
+      query(connection, UPDATE_PREV_NOTE, [prev_note_id, next_note_id]),
+    )[0];
+  }
 }
 
 module.exports = async function moveNote(
@@ -103,44 +141,11 @@ module.exports = async function moveNote(
     await connection.beginTransaction();
     let rows, error;
 
-    /**
-     * 이전 노트와의 연결 관계를 끊어줌
-     */
-    // READ NOTE LINK
-    // ?: noteId
-    [rows, error] = await safePromise(
-      this.executeQuery(connection, READ_NOTE_LINK, [noteId]),
-    );
+    // 이전 노트와 연결된 노트들의 연결 관계를 끊어줌
+    await pickNoteLink(connection, this.executeQuery, noteId);
 
-    if (error || rows.length !== 1) {
-      throw new Error();
-    }
-
-    const { prev_note_id, next_note_id } = rows[0];
-
-    if (prev_note_id !== null) {
-      // UPDATE_NEXT_NOTE
-      // ?: next_note_id, NOTE.id
-      error = await safePromise(
-        this.executeQuery(connection, UPDATE_NEXT_NOTE, [
-          next_note_id,
-          prev_note_id,
-        ]),
-      )[1];
-    }
-
-    if (next_note_id !== null) {
-      // UPDATE_NEXT_NOTE
-      // ?: prev_note_id, NOTE.id
-      error = await safePromise(
-        this.executeQuery(connection, UPDATE_PREV_NOTE, [
-          prev_note_id,
-          next_note_id,
-        ]),
-      )[0];
-    }
-
-    const isCorrectLink = await checkCorrectLink(
+    // 이동할 위치의 연결 관계가 유효한지 확인
+    await checkCorrectLink(
       connection,
       this.executeQuery,
       beforeNoteId,
@@ -148,18 +153,14 @@ module.exports = async function moveNote(
       columnId,
     );
 
-    if (!isCorrectLink) {
-      throw new Error();
-    }
-
     /**
      * 새 위치에 연관되어있는 노트들의 연결관계 갱신
      */
     if (!beforeNoteId && !afterNoteId) {
       // 새로운 column에 추가하는 것인지 확인
+      // UPDATE_LINK
+      // ?: prev_note_id, next_note_id, column_id, noteId
       [rows, error] = await safePromise(
-        // UPDATE_LINK
-        // ?: prev_note_id, next_note_id, column_id, noteId
         this.executeQuery(connection, READ_NOTE_OF_COLUMN, [columnId]),
       );
 
@@ -168,9 +169,9 @@ module.exports = async function moveNote(
       }
 
       // 새로운 column에 노트를 추가
+      // UPDATE NOTE COLUMN
+      // ?: column_id, noteId
       [rows, error] = await safePromise(
-        // UPDATE NOTE COLUMN
-        // ?: column_id, noteId
         this.executeQuery(connection, UPDATE_NOTE_COLUMN, [columnId, noteId]),
       );
     } else {

--- a/dao/method/moveNote.js
+++ b/dao/method/moveNote.js
@@ -35,11 +35,11 @@ function checkLink(firstNote, secondNote) {
 
 /**
  * 입력받은 인자의 유효성 검사
- * @param {*} connection  mysql2 connection 객체
- * @param {*} query       query를 실행하는 함수
- * @param {*} beforeId    연결 구조에서 앞에 위치한 노트
- * @param {*} afterId     연결 구조에서 뒤에 위치한 노트
- * @param {*} columnId    검사 하고자 하는 column의 id
+ * @param {Object} connection  mysql2 connection 객체
+ * @param {Function} query       query를 실행하는 함수
+ * @param {Number} beforeId    연결 구조에서 앞에 위치한 노트
+ * @param {Number} afterId     연결 구조에서 뒤에 위치한 노트
+ * @param {Number} columnId    검사 하고자 하는 column의 id
  */
 async function checkCorrectLink(
   connection,


### PR DESCRIPTION
> 노트를 드래그 후 원래 위치로 이동하는 경우에 대한 safe guard 추가

## related issue

- #66

## 설명 (what, why)

기존 로직의 경우 이동할 위치의 연결구조가 명확한지 판단을 먼저하고 DB에 이동 내용을 갱신함

원래 위치로 이동하는 경우 이동할 위치의 연결 구조를 계산하는 데 오류가 존재함.

이 로직의 순서를 이동하는 노트의 연결 구조를 끊은 뒤 검사하는 것으로 변경함

DAO의 해당 메소드의 양이 너무 많고, 보기 어려워 내부 함수로 이를 쪼갬