### PR TITLE
PR: refactor - 객체 프로퍼티와 중복되는 데이터 제거

### DIFF
--- a/src/javascripts/Components/Column.js
+++ b/src/javascripts/Components/Column.js
@@ -15,11 +15,7 @@ export default class Column extends Element {
     this.modalManager = Store.modalManager;
 
     data.notes.forEach((note) => {
-      this.notes.push({
-        id: note.id,
-        data: note,
-        dom: new Note(note),
-      });
+      this.notes.push(new Note(note));
     });
 
     this.setElement();
@@ -75,7 +71,7 @@ export default class Column extends Element {
     ul.appendChild(li);
 
     this.notes.forEach((note) => {
-      ul.appendChild(note.dom.render());
+      ul.appendChild(note.render());
     });
 
     this.ul = ul;
@@ -124,9 +120,8 @@ export default class Column extends Element {
     }
 
     const target = this.notes[targetIndex];
-    target.data.content = content;
-    target.dom.setDom(this.ul.querySelector(`li[data-id='${noteKey}']`));
-    target.dom.setContent(content);
+    target.setDom(this.ul.querySelector(`li[data-id='${noteKey}']`));
+    target.setContent(content);
   }
 
   pickNote(noteKey) {
@@ -157,16 +152,9 @@ export default class Column extends Element {
   }
 
   appendNote(data) {
-    const noteObject = {
-      id: data.id,
-      data: data,
-      dom: new Note(data),
-    };
+    const noteObject = new Note(data);
     this.pushNote(noteObject, 0);
-    this.ul.insertBefore(
-      noteObject.dom.render(),
-      this.ul.firstChild.nextSibling,
-    );
+    this.ul.insertBefore(noteObject.render(), this.ul.firstChild.nextSibling);
   }
 
   setTitle(title) {

--- a/src/javascripts/Components/Kanban.js
+++ b/src/javascripts/Components/Kanban.js
@@ -25,11 +25,7 @@ export default class Kanban extends Element {
     this.columns = [];
     this.columnsMap = new Map();
     data.columns.forEach((column) => {
-      const columnObject = {
-        id: column.id,
-        data: column,
-        dom: new Column(column),
-      };
+      const columnObject = new Column(column);
       this.columns.push(columnObject);
       this.columnsMap.set(column.id, columnObject);
     });
@@ -53,7 +49,7 @@ export default class Kanban extends Element {
 
   addColumn(wrapper) {
     this.columns.forEach((column) => {
-      wrapper.appendChild(column.dom.render());
+      wrapper.appendChild(column.render());
     });
   }
 
@@ -108,7 +104,7 @@ export default class Kanban extends Element {
     // delete hover target
     if (this.targetRemove) {
       const { id } = this.targetRemove.closest('.column').dataset;
-      const columnObject = this.columnsMap.get(parseInt(id)).dom;
+      const columnObject = this.columnsMap.get(parseInt(id));
 
       this.targetData = columnObject.pickNote(this.targetRemove.dataset.id);
 
@@ -144,7 +140,7 @@ export default class Kanban extends Element {
       this.li.classList.remove('temp_space');
 
       const { id: columnId } = this.li.closest('.column').dataset;
-      const columnObject = this.columnsMap.get(parseInt(columnId)).dom;
+      const columnObject = this.columnsMap.get(parseInt(columnId));
       const ul = columnObject.element.querySelector('ul');
 
       const prevNote = this.li.previousSibling;


### PR DESCRIPTION
> 객체 프로퍼티와 중복되는 데이터 제거

## related issue

- #67

## 설명 (what, why)

1. 객체 프로퍼티로 사용하도록 리팩토링
- 객체 프로퍼티와 중복해서 지닌 데이터때문에 데이터 변동 시,
일관되게 데이터를 모두 바꾸는 어려움이 있음