### PR TITLE
PR: feat - 유저 권한 확인

### DIFF
--- a/src/javascripts/Components/Column.js
+++ b/src/javascripts/Components/Column.js
@@ -264,6 +264,11 @@ export default class Column extends Element {
       return;
     }
 
+    if (!Store.user.permission.edit) {
+      alert('수정 권한이 없습니다.');
+      return;
+    }
+
     const note = target.closest('.note');
     const noteText = note.querySelector('.content').innerText;
     const callback = this.editNoteCallback.bind(this);
@@ -278,6 +283,11 @@ export default class Column extends Element {
       return;
     }
 
+    if (!Store.user.permission.delete) {
+      alert('삭제 권한이 없습니다.');
+      return;
+    }
+
     const callback = this.deleteNoteCallback.bind(this);
 
     Store.moduleCaller = e.target.closest('.note');
@@ -286,6 +296,11 @@ export default class Column extends Element {
 
   _renameColumnHandler(e) {
     if (e.target.tagName === 'BUTTON') {
+      return;
+    }
+
+    if (!Store.user.permission.edit) {
+      alert('수정 권한이 없습니다.');
       return;
     }
 

--- a/src/javascripts/Store/Store.js
+++ b/src/javascripts/Store/Store.js
@@ -1,6 +1,24 @@
 class Store {
   constructor() {
     this.modalManager = null;
+    this.userPermissions = {
+      1: {
+        read: true,
+        move: true,
+        edit: false,
+        delete: false,
+      },
+      2: {
+        read: true,
+        move: true,
+        edit: false,
+        delete: false,
+      },
+    };
+    this.user = {
+      name: 'superman',
+      permission: this.userPermissions[1],
+    };
   }
 }
 


### PR DESCRIPTION
> 유저 권한을 확인 추가 (수정, 삭제)

## related issue

- #71

## 설명 (what, why)
임시로 Store에 칸반에 대한 유저들 퍼미션 정보랑 유저 정보를 저장하도록 함

차후, 로그인 때 퍼미션 정보를 가져와, 유저 정보와 함께 저장할 것
(이름, 퍼미션 정보)