### PR TITLE
PR: feat - 페이지 라우팅

### DIFF
--- a/app.js
+++ b/app.js
@@ -5,6 +5,7 @@ const path = require('path');
 const cookieParser = require('cookie-parser');
 const logger = require('morgan');
 
+const spaRouters = require('./routes/spa');
 const apiRouters = require('./apis/');
 
 const app = express();
@@ -20,8 +21,8 @@ app.use(express.urlencoded({ extended: false }));
 app.use(cookieParser());
 
 app.use('/api', apiRouters);
-
 app.use(express.static(path.join(__dirname, 'dist')));
+app.use('/', spaRouters);
 
 // catch 404 and forward to error handler
 app.use(function (req, res, next) {

--- a/routes/spa.js
+++ b/routes/spa.js
@@ -1,0 +1,20 @@
+const express = require('express');
+
+const router = express.Router();
+
+const spaFile = 'index.html';
+
+router.get('/', (req, res) => {
+  res.render(spaFile);
+});
+
+router.get('/kanban', (req, res) => {
+  res.render(spaFile);
+});
+
+router.get('/error', (req, res) => {
+  // SPA 에러 핸들링 테스트용
+  res.render(spaFile);
+});
+
+module.exports = router;

--- a/src/app.js
+++ b/src/app.js
@@ -1,12 +1,28 @@
 import '@babel/polyfill';
 
+import Store from './javascripts/Store/Store.js';
+import Router from './javascripts/Components/Router.js';
+import KanbanPage from './javascripts/Components/KanbanPage.js';
+import LoginPage from './javascripts/Components/Loginpage.js';
+import ErrorPage from './javascripts/Components/ErrorPage.js';
+
 // eslint-disable-next-line no-unused-vars
 import style from './stylesheets/style.css';
 
-import KanbanPage from './javascripts/Components/KanbanPage.js';
-
 const app = document.querySelector('#app');
+const router = new Router(app);
+Store.router = router;
 
-const kanbanPage = new KanbanPage().render();
+const kanbanPage = new KanbanPage();
+const loginPage = new LoginPage();
+const errorPage = new ErrorPage();
 
-app.appendChild(kanbanPage);
+router.setPage('login', '로그인', loginPage);
+router.setPage('kanban', '칸반', kanbanPage);
+router.setErrorPage('에러', errorPage);
+
+router.setPath('/', 'login');
+router.setPath('/kanban', 'kanban');
+
+const url = new URL(document.URL);
+router.load(url);

--- a/src/javascripts/Components/Element.js
+++ b/src/javascripts/Components/Element.js
@@ -1,8 +1,13 @@
 export default class Element {
   render() {
+    if (this.runWhenRender) {
+      this.runWhenRender();
+    }
+
     if (this.setEventListeners) {
       this.setEventListeners();
     }
+
     return this.element;
   }
 }

--- a/src/javascripts/Components/ErrorPage.js
+++ b/src/javascripts/Components/ErrorPage.js
@@ -1,0 +1,45 @@
+import Element from './Element.js';
+
+// eslint-disable-next-line no-unused-vars
+import style from '../../stylesheets/error.css';
+
+export default class ErrorPage extends Element {
+  constructor() {
+    super();
+
+    this.setElement();
+  }
+
+  getWrapper() {
+    const wrapper = document.createElement('div');
+    wrapper.className = 'error-page';
+
+    return wrapper;
+  }
+
+  getContent() {
+    const container = document.createElement('div');
+    container.className = 'container';
+
+    const title = document.createElement('h1');
+    title.className = 'title';
+    title.innerText = '에러!!!';
+
+    const message = document.createElement('div');
+    message.className = 'message';
+    message.innerText = '찾는 페이지가 없습니다.';
+
+    container.appendChild(title);
+    container.appendChild(message);
+
+    return container;
+  }
+
+  setElement() {
+    const wrapper = this.getWrapper();
+    const content = this.getContent();
+
+    wrapper.appendChild(content);
+    this.element = wrapper;
+  }
+}

--- a/src/javascripts/Components/KanbanPage.js
+++ b/src/javascripts/Components/KanbanPage.js
@@ -45,11 +45,14 @@ export default class KanbanPage extends Element {
     });
   }
 
+  runWhenRender() {
+    this.fetchKanbanData();
+  }
+
   setElement() {
     const wrapper = document.createElement('div');
 
     wrapper.appendChild(this.header.render());
-    this.fetchKanbanData();
     wrapper.appendChild(this.activityLog.render());
     wrapper.appendChild(this.modalManager.render());
 

--- a/src/javascripts/Components/LoginPage.js
+++ b/src/javascripts/Components/LoginPage.js
@@ -1,5 +1,6 @@
 import Element from './Element.js';
 import UserList from './UserList.js';
+import Store from '../Store/Store.js';
 
 // eslint-disable-next-line no-unused-vars
 import login from '../../stylesheets/login.css';
@@ -41,7 +42,7 @@ const requestAccessToken = (userId) => {
     .then((response) => response.json())
     .then((data) => {
       if (data.success) {
-        window.location.href = '/kanban';
+        Store.router.href('/kanban');
         return;
       }
 
@@ -60,7 +61,10 @@ export default class LoginPage extends Element {
 
   fetchUserList() {
     setTimeout(() => {
-      this.userList = new UserList(data, requestAccessToken).render();
+      this.userList = new UserList(
+        data,
+        requestAccessToken.bind(this),
+      ).render();
       this.element.appendChild(this.userList);
     }, 0);
   }

--- a/src/javascripts/Components/Router.js
+++ b/src/javascripts/Components/Router.js
@@ -1,0 +1,76 @@
+const ERROR_PAGE_KEY = Symbol('ErrorPageKey');
+
+export default class Router {
+  constructor(app) {
+    this.app = app;
+    this.currentPage = null;
+    this.pages = new Map();
+    this.paths = new Map();
+
+    this.setEventListeners();
+  }
+
+  load(url) {
+    const pathName = url instanceof URL ? url.pathname : url;
+    let pageId = this.getPageIdByPath(pathName);
+
+    // Path 목록에 등록되지 않은 경우, 에러 페이지로 이동시키기 위함
+    if (!pageId) {
+      pageId = ERROR_PAGE_KEY;
+    }
+
+    const { page, title } = this.getPage(pageId);
+    this.render(page, title);
+  }
+
+  render(page, title) {
+    if (this.currentPage !== null) {
+      this.app.removeChild(this.currentPage);
+    }
+
+    this.currentPage = page.render();
+    this.app.appendChild(this.currentPage);
+    document.title = title;
+  }
+
+  getPageIdByPath(path) {
+    return this.paths.get(path);
+  }
+
+  setPath(path, pageId) {
+    this.paths.set(path, pageId);
+  }
+
+  getPage(id) {
+    return this.pages.get(id);
+  }
+
+  setPage(id, title, page) {
+    const data = {
+      title,
+      page,
+    };
+    this.pages.set(id, data);
+  }
+
+  setErrorPage(title, page) {
+    this.setPage(ERROR_PAGE_KEY, title, page);
+  }
+
+  href(url, data) {
+    history.pushState({ data }, document.title, url);
+    this.load(url);
+  }
+
+  replace(url, data) {
+    history.replaceState({ data }, document.title, url);
+    this.load(url);
+  }
+
+  setEventListeners() {
+    window.addEventListener('popstate', () => {
+      const url = new URL(document.URL);
+      this.load(url);
+    });
+  }
+}

--- a/src/javascripts/Store/Store.js
+++ b/src/javascripts/Store/Store.js
@@ -1,5 +1,6 @@
 class Store {
   constructor() {
+    this.router = null;
     this.modalManager = null;
     this.userPermissions = {
       1: {

--- a/src/stylesheets/error.css
+++ b/src/stylesheets/error.css
@@ -1,0 +1,20 @@
+.error-page {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  height: 400px;
+  font-size: 12px;
+}
+
+.error-page .container {
+  text-align: center;
+}
+
+.error-page .container .title {
+  font-size: 2.4em;
+}
+
+.error-page .container .message {
+  font-size: 1.6em;
+}


### PR DESCRIPTION
> 페이지 라우팅을 위한 작업

## related issue

- #71

## 설명 (what, why)
### 1. pageId, pageComponent, Path 구조
- setPage 함수로 pageId와 pageComponent를 따로 등록해두고, 여러 Path에서
재사용 할 수 있도록 함
### 2. HTML5의 pushState, replaceState를 이용해, go & back 호환
### 3. 라우터의 href, replace 함수 사용 시, 요청한 URL로 새로 그림
- 브라우저 reload 없이 화면을 그리기 위함.
### 4. 없는 URL에 대한 에러 페이지 대응
- setErrorPage로 설정, Symbol로 생성된 ID로 씀으로써 사용자가 추가한 패턴에
중복되지 않도록 함.
### 5. 렌더링이 일어날 때, 실행되는 함수를 만듬
- 현재, KanbanPage 객체가 갖고 있는 문제를 해결하기 위함
- runWhenRender 함수를 갖고 있으면, render 함수 실행 때, 실행하는 구조