### PR TITLE
PR: 추가 - activity log 적용

### DIFF
--- a/apis/index.js
+++ b/apis/index.js
@@ -1,10 +1,12 @@
 const express = require('express');
 const loginRouter = require('./login');
 const kanbanRouter = require('./kanban');
+const logRouter = require('./log');
 
 const router = express.Router();
 
 router.use(loginRouter);
 router.use(kanbanRouter);
+router.use(logRouter);
 
 module.exports = router;

--- a/apis/kanban.js
+++ b/apis/kanban.js
@@ -119,7 +119,7 @@ router.put('/note/:noteId', async (req, res) => {
     message: '',
   };
   const { noteId } = req.params;
-  const { content } = req.body;
+  const { content, contentBefore, userName } = req.body;
 
   if (!content) {
     result.message = MESSAGE.PUT_NOTE_ERROR.TEXT;
@@ -144,9 +144,8 @@ router.put('/note/:noteId', async (req, res) => {
   const logData = {
     method: CONSTANT_LOG.METHOD.MODIFY,
     type: CONSTANT_LOG.TYPE.NOTE,
-    userName: 'body에 인자로 유저정보가 필요함',
-    noteTitle: content,
-    columnTitle: 'body에 인자로 column 아이디가 필요함',
+    userName: userName,
+    noteTitle: contentBefore,
     changeTitle: content,
   };
   await safePromise(dao.createLog(logData));
@@ -172,6 +171,7 @@ router.delete('/note/:noteId', async (req, res) => {
     message: '',
   };
   const { noteId } = req.params;
+  const { userName, noteTitle } = req.body;
 
   const [ret, error] = await safePromise(dao.deleteNote(parseInt(noteId)));
 
@@ -184,9 +184,8 @@ router.delete('/note/:noteId', async (req, res) => {
   const logData = {
     method: CONSTANT_LOG.METHOD.DELETE,
     type: CONSTANT_LOG.TYPE.NOTE,
-    userName: 'body에 인자로 유저정보가 필요함',
-    noteTitle: 'body에 인자로 note 정보가 필요함',
-    columnTitle: 'body에 인자로 column 아이디가 필요함',
+    userName: userName,
+    noteTitle: noteTitle,
   };
   await safePromise(dao.createLog(logData));
 
@@ -253,7 +252,6 @@ router.patch('/note/move/:noteId', async (req, res) => {
     columnTitle: columnTitle,
     columnToTitle: columnToTitle,
   };
-  console.log(logData);
   await safePromise(dao.createLog(logData));
 
   result.success = true;

--- a/apis/kanban.js
+++ b/apis/kanban.js
@@ -3,6 +3,7 @@ const dao = require('../dao/dao.js');
 const safePromise = require('../utils/safePromise');
 
 const MESSAGE = require('./constants/message');
+const CONSTANT_LOG = require('../dao/constants/log');
 
 const router = express.Router();
 
@@ -86,6 +87,15 @@ router.put('/column/:columnId', async (req, res) => {
     return;
   }
 
+  const logData = {
+    method: CONSTANT_LOG.METHOD.CREATE,
+    type: CONSTANT_LOG.TYPE.NOTE,
+    userName: user,
+    noteTitle: content,
+    columnTitle: 'body에 인자로 column 아이디가 필요함',
+  };
+  await safePromise(dao.createLog(logData));
+
   result.success = true;
   result.message = MESSAGE.PUT_NOTE_SUCCESS.TEXT;
   result.data = note;
@@ -131,6 +141,16 @@ router.put('/note/:noteId', async (req, res) => {
     return;
   }
 
+  const logData = {
+    method: CONSTANT_LOG.METHOD.MODIFY,
+    type: CONSTANT_LOG.TYPE.NOTE,
+    userName: 'body에 인자로 유저정보가 필요함',
+    noteTitle: content,
+    columnTitle: 'body에 인자로 column 아이디가 필요함',
+    changeTitle: content,
+  };
+  await safePromise(dao.createLog(logData));
+
   result.success = true;
   result.message = MESSAGE.UPDATE_NOTE_SUCCESS.TEXT;
   res.status(MESSAGE.UPDATE_NOTE_SUCCESS.STATUS_CODE).json(result);
@@ -160,6 +180,15 @@ router.delete('/note/:noteId', async (req, res) => {
     res.status(MESSAGE.DELETE_NOTE_ERROR.STATUS_CODE).json(result);
     return;
   }
+
+  const logData = {
+    method: CONSTANT_LOG.METHOD.DELETE,
+    type: CONSTANT_LOG.TYPE.NOTE,
+    userName: 'body에 인자로 유저정보가 필요함',
+    noteTitle: 'body에 인자로 note 정보가 필요함',
+    columnTitle: 'body에 인자로 column 아이디가 필요함',
+  };
+  await safePromise(dao.createLog(logData));
 
   result.success = true;
   result.message = MESSAGE.DELETE_NOTE_SUCCESS.TEXT;
@@ -207,6 +236,15 @@ router.patch('/note/move/:noteId', async (req, res) => {
     res.status(MESSAGE.MOVE_NOTE_ERROR.STATUS_CODE).json(result);
     return;
   }
+
+  const logData = {
+    method: CONSTANT_LOG.METHOD.MOVE,
+    type: CONSTANT_LOG.TYPE.NOTE,
+    userName: 'body에 인자로 유저정보가 필요함',
+    noteTitle: 'body에 인자로 note 정보가 필요함',
+    columnTitle: 'body에 인자로 column 아이디가 필요함',
+  };
+  await safePromise(dao.createLog(logData));
 
   result.success = true;
   result.message = MESSAGE.MOVE_NOTE_SUCCESS.TEXT;

--- a/apis/kanban.js
+++ b/apis/kanban.js
@@ -215,7 +215,15 @@ router.patch('/note/move/:noteId', async (req, res) => {
   };
 
   const { noteId } = req.params;
-  let { beforeNoteId, afterNoteId, columnId } = req.body;
+  let {
+    beforeNoteId,
+    afterNoteId,
+    columnId,
+    userName,
+    noteTitle,
+    columnTitle,
+    columnToTitle,
+  } = req.body;
 
   beforeNoteId = isNaN(parseInt(beforeNoteId)) ? null : parseInt(beforeNoteId);
   afterNoteId = isNaN(parseInt(afterNoteId)) ? null : parseInt(afterNoteId);
@@ -240,10 +248,12 @@ router.patch('/note/move/:noteId', async (req, res) => {
   const logData = {
     method: CONSTANT_LOG.METHOD.MOVE,
     type: CONSTANT_LOG.TYPE.NOTE,
-    userName: 'body에 인자로 유저정보가 필요함',
-    noteTitle: 'body에 인자로 note 정보가 필요함',
-    columnTitle: 'body에 인자로 column 아이디가 필요함',
+    userName: userName,
+    noteTitle: noteTitle,
+    columnTitle: columnTitle,
+    columnToTitle: columnToTitle,
   };
+  console.log(logData);
   await safePromise(dao.createLog(logData));
 
   result.success = true;

--- a/apis/log.js
+++ b/apis/log.js
@@ -1,0 +1,48 @@
+const express = require('express');
+const dao = require('../dao/dao.js');
+const safePromise = require('../utils/safePromise');
+
+const MESSAGE = require('./constants/message');
+
+const router = express.Router();
+
+/**
+ * @api {get} /get/:kanbanId Kanban 데이터 요청
+ * @apiName get kanban
+ * @apiGroup Kanban
+ *
+ * @apiParam {Number} kanbanId kanban 보드의 id [params]
+ *
+ * @apiSuccess {Boolean} success API 호출 성공 여부
+ * @apiSuccess {String} message 응답 결과 메시지
+ */
+router.get('/log/:page', async (req, res) => {
+  const result = {
+    success: false,
+    message: '',
+  };
+  const { page } = req.params;
+
+  const [logs, error] = await safePromise(dao.readLogs(parseInt(page)));
+
+  // console.log(logs);
+
+  if (error) {
+    result.message = '로그를 읽는데 문제가 발생했습니다.';
+    res.status(MESSAGE.GET_KANBAN_MYSQL_ERROR.STATUS_CODE).json(result);
+    return;
+  }
+
+  if (logs.length === 0) {
+    result.message = '로그가 없습니다.';
+    res.status(MESSAGE.GET_KANBAN_ERROR.STATUS_CODE).json(result);
+    return;
+  }
+
+  result.success = true;
+  result.message = '로그를 읽었습니다.';
+  result.data = logs;
+  res.status(MESSAGE.GET_KANBAN_SUCCESS.STATUS_CODE).json(result);
+});
+
+module.exports = router;

--- a/dao/DataAccessObject.js
+++ b/dao/DataAccessObject.js
@@ -15,6 +15,7 @@ const updateNote = require('./method/updateNote');
 const deleteNote = require('./method/deleteNote');
 const moveNote = require('./method/moveNote');
 const createLog = require('./method/createLog');
+const readLogs = require('./method/readLogs');
 
 class DataAccessObject {
   constructor(option) {
@@ -129,5 +130,6 @@ DataAccessObject.prototype.updateNote = updateNote;
 DataAccessObject.prototype.deleteNote = deleteNote;
 DataAccessObject.prototype.moveNote = moveNote;
 DataAccessObject.prototype.createLog = createLog;
+DataAccessObject.prototype.readLogs = readLogs;
 
 module.exports = DataAccessObject;

--- a/dao/DataAccessObject.js
+++ b/dao/DataAccessObject.js
@@ -14,6 +14,7 @@ const createNote = require('./method/createNote');
 const updateNote = require('./method/updateNote');
 const deleteNote = require('./method/deleteNote');
 const moveNote = require('./method/moveNote');
+const createLog = require('./method/createLog');
 
 class DataAccessObject {
   constructor(option) {
@@ -127,5 +128,6 @@ DataAccessObject.prototype.createNote = createNote;
 DataAccessObject.prototype.updateNote = updateNote;
 DataAccessObject.prototype.deleteNote = deleteNote;
 DataAccessObject.prototype.moveNote = moveNote;
+DataAccessObject.prototype.createLog = createLog;
 
 module.exports = DataAccessObject;

--- a/dao/constants/log.js
+++ b/dao/constants/log.js
@@ -1,0 +1,15 @@
+const TYPE = {
+  NOTE: 'NOTE',
+  COLUMN: 'COLUMN',
+};
+const METHOD = {
+  CREATE: 'CREATE',
+  DELETE: 'DELETE',
+  MOVE: 'MOVE',
+  MODIFY: 'MODIFY',
+};
+
+module.exports = {
+  TYPE,
+  METHOD,
+};

--- a/dao/dto/Log.js
+++ b/dao/dto/Log.js
@@ -1,0 +1,37 @@
+class Log {
+  /**
+   * 액티비티 로그의 정보를 전달해주는 DTO
+   * @param {Bineary Row} data { id, type, method, ?note_id, ?column_from, ?column_to, ?content_before, ?content_after }
+   * @param {Number} id 액티비티 로그의 id
+   * @param {String} type 노트, 컬럼 여부 ['note', 'column']
+   * @param {String} method 작업의 종류 ['create', 'delete', 'move', 'modify']
+   * @param {Number} note_id 해당 노트 id
+   * @param {Number} column_from 해당 컬럼 id, 혹은 이동 전 컬럼
+   * @param {Number} clumn_to 이동한 컬럼 id
+   * @param {String} content_before 변경전 내용
+   * @param {String} content_after 변경후 내용
+   */
+  constructor(data) {
+    const {
+      id,
+      type,
+      method,
+      note_id,
+      column_from,
+      column_to,
+      content_before,
+      content_after,
+    } = data;
+
+    this.id = id;
+    this.type = type;
+    this.method = method;
+    this.noteId = note_id;
+    this.columnFrom = column_from;
+    this.columnTo = column_to;
+    this.contentBefore = content_before;
+    this.contentAfter = content_after;
+  }
+}
+
+module.exports = Log;

--- a/dao/dto/Log.js
+++ b/dao/dto/Log.js
@@ -1,36 +1,36 @@
 class Log {
   /**
    * 액티비티 로그의 정보를 전달해주는 DTO
-   * @param {Bineary Row} data { id, type, method, ?note_id, ?column_from, ?column_to, ?content_before, ?content_after }
-   * @param {Number} id 액티비티 로그의 id
-   * @param {String} type 노트, 컬럼 여부 ['note', 'column']
-   * @param {String} method 작업의 종류 ['create', 'delete', 'move', 'modify']
-   * @param {Number} note_id 해당 노트 id
-   * @param {Number} column_from 해당 컬럼 id, 혹은 이동 전 컬럼
-   * @param {Number} clumn_to 이동한 컬럼 id
-   * @param {String} content_before 변경전 내용
-   * @param {String} content_after 변경후 내용
+   * @param {Bineary Row} row
+   * @param {Number} id 로그의 id
+   * @param {String} type 노트, 컬럼 여부 ['NOTE', 'COLUMN']
+   * @param {String} method 작업의 종류 ['CREATE', 'DELETE', 'MOVE', 'MODIFY']
+   * @param {String} user_name 사용자의 이름
+   * @param {String} note_title 해당 노트의 내용
+   * @param {String} column_title 해당 컬럼의
+   * @param {String} column_to_title 이동한 컬럼 id
+   * @param {String} change_title 변경전 내용
    */
-  constructor(data) {
+  constructor(row) {
     const {
       id,
       type,
       method,
-      note_id,
-      column_from,
-      column_to,
-      content_before,
-      content_after,
-    } = data;
+      user_name,
+      note_title,
+      column_title,
+      column_to_title,
+      change_title,
+    } = row;
 
     this.id = id;
     this.type = type;
     this.method = method;
-    this.noteId = note_id;
-    this.columnFrom = column_from;
-    this.columnTo = column_to;
-    this.contentBefore = content_before;
-    this.contentAfter = content_after;
+    this.userName = user_name;
+    this.noteTitle = note_title;
+    this.columnTitle = column_title;
+    this.columnToTitle = column_to_title;
+    this.changeTitle = change_title;
   }
 }
 

--- a/dao/method/createLog.js
+++ b/dao/method/createLog.js
@@ -1,0 +1,166 @@
+const safePromise = require('../../utils/safePromise');
+
+const Log = require('../dto/Log');
+const CONSTANT = require('../constants/log');
+
+const INSERT_LOG = `INSERT INTO ACTIVITY_LOG 
+(method, \`type\`, note_id, \`column\`, column_to, content_before, content_after)
+VALUES (?, ?, ?, ?, ?, ?, ?);`;
+
+function trimUpperCase(string) {
+  if (typeof string !== 'string') {
+    return null;
+  }
+  let upperCase = string.toUpperCase();
+  if (CONSTANT.METHOD[upperCase]) {
+    return CONSTANT.METHOD[upperCase];
+  }
+
+  if (CONSTANT.TYPE[upperCase]) {
+    return CONSTANT.TYPE[upperCase];
+  }
+  return null;
+}
+
+function trimNumber(string) {
+  const number = parseInt(string);
+  if (isNaN(number)) {
+    return null;
+  }
+  return number;
+}
+
+/**
+ * 객체들의 type을 명확히 해주는 함수
+ * @param {Object} data { type, method, ?noteId, ?columnId, ?columnTo, ?contentBefore, ?contentAfter }
+ * @returns {Object} data 가공한 데이터
+ */
+function trimData({
+  type,
+  method,
+  noteId,
+  columnId,
+  columnTo,
+  contentBefore,
+  contentAfter,
+}) {
+  const data = {};
+
+  data.method = trimUpperCase(method);
+  data.type = trimUpperCase(type);
+  data.noteId = trimNumber(noteId);
+  data.columnId = trimNumber(columnId);
+  data.columnTo = trimNumber(columnTo);
+  data.contentBefore = contentBefore ? `${contentBefore}` : null;
+  data.contentAfter = contentAfter ? `${contentAfter}` : null;
+
+  return data;
+}
+
+function checkParams({
+  type,
+  method,
+  noteId,
+  columnId,
+  columnTo,
+  contentBefore,
+  contentAfter,
+}) {
+  switch (type) {
+    case CONSTANT.TYPE.COLUMN: {
+      if (method === CONSTANT.METHOD.CREATE && (!columnId || !contentAfter)) {
+        throw new Error('컬럼 생성 인자 부족');
+      }
+      if (method === CONSTANT.METHOD.DELETE && !columnId) {
+        throw new Error('컬럼 삭제 인자 부족');
+      }
+      if (
+        method === CONSTANT.METHOD.MODIFY &&
+        (!columnId || !contentAfter || !contentBefore)
+      ) {
+        throw new Error('컬럼 삭제 인자 부족');
+      }
+      break;
+    }
+    case CONSTANT.TYPE.NOTE: {
+      if (method === CONSTANT.METHOD.CREATE && (!noteId || !contentAfter)) {
+        throw new Error('노트 생성 인자 부족');
+      }
+      if (method === CONSTANT.METHOD.DELETE && !noteId) {
+        throw new Error('노트 삭제 인자 부족');
+      }
+      if (
+        method === CONSTANT.METHOD.MODIFY &&
+        (!noteId || !contentAfter || !contentBefore)
+      ) {
+        throw new Error('노트 변경 인자 부족');
+      }
+      if (
+        method === CONSTANT.METHOD.MOVE &&
+        (!noteId || !columnId || !columnTo)
+      ) {
+        throw new Error('노트 이동 인자 부족');
+      }
+      break;
+    }
+  }
+}
+
+/**
+ * 로그를 생성하는 method
+ * @param {Object} data { type, method, ?noteId, ?columnId, ?columnTo, ?contentBefore, ?contentAfter }
+ */
+module.exports = async function createLog(data) {
+  const {
+    type,
+    method,
+    noteId,
+    columnId,
+    columnTo,
+    contentBefore,
+    contentAfter,
+  } = trimData(data);
+
+  if (!method || !type) {
+    return false;
+  }
+
+  const [connection, connectionError] = await safePromise(this.getConnection());
+  if (connectionError) {
+    throw connectionError;
+  }
+  let result = false;
+
+  try {
+    await connection.beginTransaction();
+    // 각 method, type 별로 prametors가 제대로 있는지 검사
+    checkParams(data);
+
+    // INSERT_LOG
+    // ?: method, type, note_id, column, column_to, content_before, content_after
+    const [row, rowError] = await safePromise(
+      this.executeQuery(connection, INSERT_LOG, [
+        method,
+        type,
+        noteId,
+        columnId,
+        columnTo,
+        contentBefore,
+        contentAfter,
+      ]),
+    );
+
+    if (rowError || row.affectedRows !== 1) {
+      throw new Error('로그를 생성하는데 에러가 있습니다.');
+    }
+
+    await connection.commit();
+    result = new Log(data);
+  } catch (error) {
+    connection.rollback();
+  } finally {
+    connection.release();
+  }
+
+  return result;
+};

--- a/dao/method/createLog.js
+++ b/dao/method/createLog.js
@@ -4,7 +4,15 @@ const Log = require('../dto/Log');
 const CONSTANT = require('../constants/log');
 
 const INSERT_LOG = `INSERT INTO ACTIVITY_LOG 
-(method, \`type\`, note_id, \`column\`, column_to, content_before, content_after)
+(
+  \`method\`,
+  \`type\`,
+  user_name,
+  note_title,
+  column_title,
+  column_to_title,
+  change_title
+)
 VALUES (?, ?, ?, ?, ?, ?, ?);`;
 
 function trimUpperCase(string) {
@@ -22,82 +30,74 @@ function trimUpperCase(string) {
   return null;
 }
 
-function trimNumber(string) {
-  const number = parseInt(string);
-  if (isNaN(number)) {
-    return null;
-  }
-  return number;
-}
-
 /**
  * 객체들의 type을 명확히 해주는 함수
- * @param {Object} data { type, method, ?noteId, ?columnId, ?columnTo, ?contentBefore, ?contentAfter }
+ * @param {Object} data
  * @returns {Object} data 가공한 데이터
  */
 function trimData({
   type,
   method,
-  noteId,
-  columnId,
-  columnTo,
-  contentBefore,
-  contentAfter,
+  userName,
+  noteTitle,
+  columnTitle,
+  columnToTitle,
+  changeTitle,
 }) {
   const data = {};
 
   data.method = trimUpperCase(method);
   data.type = trimUpperCase(type);
-  data.noteId = trimNumber(noteId);
-  data.columnId = trimNumber(columnId);
-  data.columnTo = trimNumber(columnTo);
-  data.contentBefore = contentBefore ? `${contentBefore}` : null;
-  data.contentAfter = contentAfter ? `${contentAfter}` : null;
+  data.userName = userName ? `${userName}` : null;
+  data.noteTitle = noteTitle ? `${noteTitle}` : null;
+  data.columnTitle = columnTitle ? `${columnTitle}` : null;
+  data.columnToTitle = columnToTitle ? `${columnToTitle}` : null;
+  data.changeTitle = changeTitle ? `${changeTitle}` : null;
 
   return data;
 }
 
 function checkParams({
-  type,
   method,
-  noteId,
-  columnId,
-  columnTo,
-  contentBefore,
-  contentAfter,
+  type,
+  userName,
+  noteTitle,
+  columnTitle,
+  columnToTitle,
+  changeTitle,
 }) {
   switch (type) {
     case CONSTANT.TYPE.COLUMN: {
-      if (method === CONSTANT.METHOD.CREATE && (!columnId || !contentAfter)) {
+      if (method === CONSTANT.METHOD.CREATE && (!userName || !columnTitle)) {
         throw new Error('컬럼 생성 인자 부족');
       }
-      if (method === CONSTANT.METHOD.DELETE && !columnId) {
+      if (method === CONSTANT.METHOD.DELETE && (!userName || !columnTitle)) {
         throw new Error('컬럼 삭제 인자 부족');
       }
       if (
         method === CONSTANT.METHOD.MODIFY &&
-        (!columnId || !contentAfter || !contentBefore)
+        (!userName || !columnTitle || !changeTitle)
       ) {
-        throw new Error('컬럼 삭제 인자 부족');
+        throw new Error('컬럼 수정 인자 부족');
       }
       break;
     }
     case CONSTANT.TYPE.NOTE: {
-      if (method === CONSTANT.METHOD.CREATE && (!noteId || !contentAfter)) {
+      if (method === CONSTANT.METHOD.CREATE && (!userName || !noteTitle)) {
         throw new Error('노트 생성 인자 부족');
       }
-      if (method === CONSTANT.METHOD.DELETE && !noteId) {
+      if (method === CONSTANT.METHOD.DELETE && (!userName || !noteTitle)) {
         throw new Error('노트 삭제 인자 부족');
       }
       if (
         method === CONSTANT.METHOD.MODIFY &&
-        (!noteId || !contentAfter || !contentBefore)
+        (!userName || !noteTitle || !changeTitle)
       ) {
         throw new Error('노트 변경 인자 부족');
       }
       if (
         method === CONSTANT.METHOD.MOVE &&
-        (!noteId || !columnId || !columnTo)
+        (!userName || !noteTitle || !columnTitle || !columnToTitle)
       ) {
         throw new Error('노트 이동 인자 부족');
       }
@@ -108,45 +108,48 @@ function checkParams({
 
 /**
  * 로그를 생성하는 method
+ * @param {Object} connection  mysql2 connection 객체
+ * @param {Function} query     query를 실행하는 함수
  * @param {Object} data { type, method, ?noteId, ?columnId, ?columnTo, ?contentBefore, ?contentAfter }
  */
 module.exports = async function createLog(data) {
+  data = trimData(data);
   const {
-    type,
     method,
-    noteId,
-    columnId,
-    columnTo,
-    contentBefore,
-    contentAfter,
-  } = trimData(data);
+    type,
+    userName,
+    noteTitle,
+    columnTitle,
+    columnToTitle,
+    changeTitle,
+  } = data;
 
   if (!method || !type) {
     return false;
   }
-
   const [connection, connectionError] = await safePromise(this.getConnection());
   if (connectionError) {
     throw connectionError;
   }
-  let result = false;
 
+  let result = false;
   try {
     await connection.beginTransaction();
     // 각 method, type 별로 prametors가 제대로 있는지 검사
+
     checkParams(data);
 
     // INSERT_LOG
-    // ?: method, type, note_id, column, column_to, content_before, content_after
+    // ?: method, type, user_name, note_title, column_title, column_to_title, change_title
     const [row, rowError] = await safePromise(
       this.executeQuery(connection, INSERT_LOG, [
         method,
         type,
-        noteId,
-        columnId,
-        columnTo,
-        contentBefore,
-        contentAfter,
+        userName,
+        noteTitle,
+        columnTitle,
+        columnToTitle,
+        changeTitle,
       ]),
     );
 

--- a/dao/method/readLogs.js
+++ b/dao/method/readLogs.js
@@ -1,0 +1,39 @@
+const safePromise = require('../../utils/safePromise');
+
+const Log = require('../dto/Log');
+
+const SIZE = 4;
+
+const READ_NOTE_LINK = `SELECT 
+id, \`type\`, method, user_name, note_title, column_title, column_to_title, change_title
+FROM ACTIVITY_LOG
+ORDER BY created_at DESC
+LIMIT ${SIZE} OFFSET ?;`;
+
+/**
+ * 해당 노트와 연결된 노트들의 연결관계를 갱신해줌
+ * @param {Number} page        보여줄 페이지
+ */
+module.exports = async function readLogs(page) {
+  const [connection, connectionError] = await safePromise(this.getConnection());
+  if (connectionError) {
+    throw connectionError;
+  }
+
+  // READ NOTE LINK
+  // ?: noteId
+  let [rows, error] = await safePromise(
+    this.executeQuery(connection, READ_NOTE_LINK, [(page - 1) * SIZE]),
+  );
+
+  // console.log(rows);
+
+  if (error) {
+    return false;
+  }
+  const data = [];
+  Array.from(rows).forEach((row) => {
+    data.push(new Log(row));
+  });
+  return data;
+};

--- a/src/javascripts/Components/ActivityLog.js
+++ b/src/javascripts/Components/ActivityLog.js
@@ -4,27 +4,13 @@ import Log from './Log.js';
 // eslint-disable-next-line no-unused-vars
 import style from '../../stylesheets/activityLog.css';
 
-const mockData = {
-  user: '@hello',
-  noteTitle: '집에가기',
-  method: 'moved',
-  columnFrom: 'Todo',
-  columnTo: 'Done',
-  time: '1 min ago',
-};
-
-const mockDatas = [];
-
-for (let i = 0; i < 10; i++) {
-  mockDatas.push(mockData);
-}
-
 export default class ActivityLog extends Element {
   constructor() {
     super();
 
     this.logs = [];
 
+    this.page = 1;
     this.wrapper = undefined;
     this.closeButton = undefined;
     this.ul = undefined;
@@ -76,19 +62,50 @@ export default class ActivityLog extends Element {
   }
 
   appendLi(data) {
+    data.time = '1 분전';
     const log = new Log(data);
     this.ul.appendChild(log.render());
   }
 
+  hideMoreButton() {
+    this.moreButton.hidden = true;
+  }
+
   fetchData() {
-    mockDatas.forEach((data) => {
-      this.logs.push(data);
-      this.appendLi(data);
-    });
+    fetch(`/api/log/${this.page}`, {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+        Accept: 'application/json',
+      },
+    })
+      .then((res) => res.json())
+      .then((res) => {
+        const logs = res.data;
+
+        if (logs && logs.length !== 0) {
+          logs.forEach((data) => {
+            this.logs.push(data);
+            this.appendLi(data);
+          });
+          this.page += 1;
+        } else {
+          this.hideMoreButton();
+        }
+      });
   }
 
   openActivityLog() {
+    this.ul.innerHTML = '';
+    this.moreButton.hidden = false;
+    this.resetPage();
+    this.fetchData();
+
     this.element.classList.remove('close');
+  }
+
+  resetPage() {
+    this.page = 1;
   }
 
   setElement() {

--- a/src/javascripts/Components/Column.js
+++ b/src/javascripts/Components/Column.js
@@ -189,6 +189,8 @@ export default class Column extends Element {
     const noteId = note.dataset.id;
     const body = {
       content: newText,
+      userName: 'hardcoding admin',
+      contentBefore: previousContent,
     };
 
     fetch(`/api/note/${noteId}`, {
@@ -217,8 +219,16 @@ export default class Column extends Element {
     const note = Store.moduleCaller;
     const noteId = note.dataset.id;
 
+    console.log(note);
+
+    const body = {
+      userName: 'hardcoding admin',
+      noteTitle: note.querySelector('.content').innerText,
+    };
+
     fetch(`/api/note/${noteId}`, {
       method: 'DELETE',
+      body: JSON.stringify(body),
       headers: {
         'Content-Type': 'application/json',
         Accept: 'application/json',

--- a/src/javascripts/Components/Kanban.js
+++ b/src/javascripts/Components/Kanban.js
@@ -34,6 +34,8 @@ export default class Kanban extends Element {
       this.columnsMap.set(column.id, columnObject);
     });
 
+    this.beforeColumnTitle = undefined;
+    this.beforeColumnId = undefined;
     this.hover = new Hover();
     this.li = undefined;
     this.targetRemove = undefined;
@@ -124,13 +126,17 @@ export default class Kanban extends Element {
     }
 
     this.targetRemove = event.target.closest('li');
-
     if (!this.targetRemove || this.targetRemove.className === 'start_point') {
       return;
     }
+    const { id: columnId } = this.targetRemove.closest('.column').dataset;
+    const columnObject = this.columnsMap.get(parseInt(columnId));
 
     this.clicked = true;
     this.li = this.targetRemove.cloneNode(true);
+    this.beforeColumnId = columnObject.id;
+    this.beforeColumnTitle = columnObject.data.title;
+
     this.li.classList.add('temp_space');
 
     this.hover.changeInnerDom(this.targetRemove.cloneNode(true));
@@ -159,6 +165,10 @@ export default class Kanban extends Element {
         beforeNoteId,
         afterNoteId,
         columnId,
+        userName: 'hardcoding admin',
+        noteTitle: this.targetData.data.content,
+        columnTitle: this.beforeColumnTitle,
+        columnToTitle: columnObject.title,
       };
 
       fetch(`/api/note/move/${this.li.dataset.id}`, {
@@ -183,6 +193,8 @@ export default class Kanban extends Element {
           }
           this.targetData = undefined;
           this.li = undefined;
+          this.beforeColumnId = undefined;
+          this.beforeColumnTitle = undefined;
         });
     }
     this.hover.clearInnerDom();

--- a/src/javascripts/Components/Log.js
+++ b/src/javascripts/Components/Log.js
@@ -4,11 +4,13 @@ export default class Log extends Element {
   constructor(data) {
     super();
 
-    this.user = data.user;
+    this.id = data.id;
+    this.user = data.userName;
     this.noteTitle = data.noteTitle;
     this.method = data.method;
-    this.columnFrom = data.columnFrom;
-    this.columnTo = data.columnTo;
+    this.columnFrom = data.columnTitle;
+    this.columnTo = data.columnToTitle;
+    this.changeTitle = data.changeTitle;
     this.time = data.time;
 
     this.setElement();
@@ -24,32 +26,45 @@ export default class Log extends Element {
     const log = document.createElement('div');
     log.className = 'log';
 
-    const userP = document.createElement('p');
-    userP.className = 'user';
-    userP.innerText = this.user;
-    const methodP = document.createElement('p');
-    methodP.innerText = this.method;
-    const noteTitleP = document.createElement('p');
-    noteTitleP.className = 'title';
-    noteTitleP.innerText = this.noteTitle;
-    const fromP = document.createElement('p');
-    fromP.innerText = 'from';
-    const columnFromP = document.createElement('p');
-    columnFromP.innerText = this.columnFrom;
-    const toP = document.createElement('p');
-    toP.innerText = 'to';
-    const columnToP = document.createElement('p');
-    columnToP.innerText = this.columnTo;
+    switch (this.method) {
+      case 'CREATE': {
+        log.innerHTML = `<p class="user">${
+          this.user
+        }</p><p>${this.method.toLowerCase()}</p><p class="title">${
+          this.noteTitle
+        }</p><p>at</p><p>${this.columnFrom}</p>`;
 
-    log.appendChild(userP);
-    log.appendChild(methodP);
-    log.appendChild(noteTitleP);
-    log.appendChild(fromP);
-    log.appendChild(columnFromP);
+        break;
+      }
+      case 'MOVE': {
+        log.innerHTML = `<p class="user">${
+          this.user
+        }</p><p>${this.method.toLowerCase()}</p><p class="title">${
+          this.noteTitle
+        }</p><p>from</p><p>${this.columnFrom}</p><p>to</p><p>${
+          this.columnTo
+        }</p>`;
 
-    if (this.method === 'moved') {
-      log.appendChild(toP);
-      log.appendChild(columnToP);
+        break;
+      }
+      case 'MODIFY': {
+        log.innerHTML = `<p class="user">${
+          this.user
+        }</p><p>${this.method.toLowerCase()}</p><p class="title">${
+          this.noteTitle
+        }</p><p>to</p><p>${this.changeTitle}</p>`;
+
+        break;
+      }
+      case 'DELETE': {
+        log.innerHTML = `<p class="user">${
+          this.user
+        }</p><p>${this.method.toLowerCase()}</p><p class="title">${
+          this.noteTitle
+        }</p><p>at</p><p>${this.columnFrom}</p>`;
+
+        break;
+      }
     }
 
     return log;


### PR DESCRIPTION
> 액티비티 로그를 database에서 받아오는 기능 추가

## related issue

- #8 
- #32 
- #27 

## 설명 (what, why)

액티비티 로그를 생성하는 로직 추가

database schema 구조를 변경하는 이유
- noteId 등을 외래키로 설정하거나, 그렇게 title을 받아오는 경우, 이후에 내용이 바뀌었을 때, 이전 기록의 내용들도 title이 전부 바뀜
- 따라서 log가 생성될 때의 기록만 나타내도록 구성

액티비티 로그의 데이터를 서버에서 받아오도록 수정

Log 컴포넌트의 인자의 이름을 API로 받아온 데이터와 맞춤

페이지네이션은 offset과 limit으로 구현함