### PR TITLE
PR: feat - 토큰으로 유저 정보 연동 및 로그인 여부 확인

### DIFF
--- a/apis/constants/config.js
+++ b/apis/constants/config.js
@@ -1,4 +1,5 @@
 module.exports = {
-  COOKIE_MAX_AGE: require('../../dao/constants/config').TOKEN_AGE_SECONDS,
+  COOKIE_MAX_AGE:
+    require('../../dao/constants/config').TOKEN_AGE_SECONDS * 1000,
   COOKIE_NAME: 'token_id',
 };

--- a/apis/constants/message.js
+++ b/apis/constants/message.js
@@ -15,6 +15,19 @@ module.exports = {
     TEXT: '알 수 없는 오류가 발생했습니다.',
     STATUS_CODE: 503,
   },
+  GET_USER_SUCCESS: {
+    TEXT: '성공적으로 데이터를 가져왔습니다.',
+    STATUS_CODE: 200,
+  },
+  GET_USER_CANNOT_FOUND_TOKEN: {
+    TEXT: '토큰 정보를 확인할 수 없습니다.',
+    STATUS_CODE: 400,
+  },
+  GET_USER_ERROR: {
+    TEXT: '오류가 발생했습니다.',
+    STATUS_CODE: 500,
+  },
+
   GET_KANBAN_SUCCESS: {
     TEXT: '성공적으로 데이터를 가져왔습니다',
     STATUS_CODE: 200,

--- a/apis/login.js
+++ b/apis/login.js
@@ -63,4 +63,48 @@ router.post(
   },
 );
 
+router.get('/user/info', async (req, res, next) => {
+  const result = {
+    success: false,
+    message: '',
+  };
+
+  const cookieToken = req.cookies[CONFIG.COOKIE_NAME];
+  if (!cookieToken) {
+    result.message = MESSAGE.GET_USER_CANNOT_FOUND_TOKEN.TEXT;
+    res.status(MESSAGE.GET_USER_CANNOT_FOUND_TOKEN.STATUS_CODE).json(result);
+    return;
+  }
+
+  const [tokenInfo, tokenInfoError] = await safePromise(
+    dao.getTokenInfo(cookieToken),
+  );
+
+  if (tokenInfoError) {
+    result.message = MESSAGE.GET_USER_CANNOT_FOUND_TOKEN.TEXT;
+    res.status(MESSAGE.GET_USER_CANNOT_FOUND_TOKEN.STATUS_CODE).json(result);
+    return;
+  }
+
+  const [user, userError] = await safePromise(
+    dao.getUserById(tokenInfo.userId),
+  );
+
+  // 만료 여부 추가 필요
+  if (userError) {
+    result.message = MESSAGE.GET_USER_CANNOT_FOUND_TOKEN.TEXT;
+    res.status(MESSAGE.GET_USER_CANNOT_FOUND_TOKEN.STATUS_CODE).json(result);
+    return;
+  }
+
+  result.success = true;
+  result.message = MESSAGE.GET_USER_SUCCESS.TEXT;
+  result.info = {
+    id: user.id,
+    name: user.name,
+  };
+
+  res.status(MESSAGE.GET_USER_SUCCESS.STATUS_CODE).json(result);
+});
+
 module.exports = router;

--- a/dao/dto/UserToken.js
+++ b/dao/dto/UserToken.js
@@ -1,9 +1,9 @@
 class UserToken {
   constructor(attrs) {
     this.id = attrs?.id;
-    this.userId = attrs?.userId;
+    this.userId = attrs?.userId ?? attrs?.user_id;
     this.token = attrs?.token;
-    this.expiredAt = attrs?.expiredAt;
+    this.expiredAt = attrs?.expiredAt ?? attrs?.expired_at;
   }
 }
 

--- a/src/app.js
+++ b/src/app.js
@@ -1,6 +1,7 @@
 import '@babel/polyfill';
 
 import Store from './javascripts/Store/Store.js';
+import { getCookie, deleteCookie } from './javascripts/Utils/cookie.js';
 import Router from './javascripts/Components/Router.js';
 import KanbanPage from './javascripts/Components/KanbanPage.js';
 import LoginPage from './javascripts/Components/Loginpage.js';
@@ -23,6 +24,33 @@ router.setErrorPage('에러', errorPage);
 
 router.setPath('/', 'login');
 router.setPath('/kanban', 'kanban');
+
+if (getCookie('token_id') && Store.user.id === null) {
+  Store.isRequestTokenInfo = true;
+  fetch('/api/user/info', {
+    method: 'GET',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  })
+    .then((response) => response.json())
+    .then((data) => {
+      if (data.success) {
+        Store.user = {
+          id: data.info.id,
+          name: data.info.name,
+          permission: Store.userPermissions[data.info.id],
+        };
+        return;
+      }
+
+      alert(`${data.message}`);
+      Store.isRequestTokenInfo = false;
+      deleteCookie('token_id');
+      window.location.href = '/';
+    })
+    .catch((error) => console.log(error));
+}
 
 const url = new URL(document.URL);
 router.load(url);

--- a/src/javascripts/Components/KanbanPage.js
+++ b/src/javascripts/Components/KanbanPage.js
@@ -46,6 +46,11 @@ export default class KanbanPage extends Element {
   }
 
   runWhenRender() {
+    if (Store.user.id === null && !Store.isRequestTokenInfo) {
+      alert('로그인이 필요합니다.');
+      window.location.href = '/';
+      return;
+    }
     this.fetchKanbanData();
   }
 

--- a/src/javascripts/Utils/cookie.js
+++ b/src/javascripts/Utils/cookie.js
@@ -1,0 +1,19 @@
+function getCookie(name) {
+  let matches = document.cookie.match(
+    new RegExp(
+      '(?:^|; )' +
+        name.replace(/([\.$?*|{}\(\)\[\]\\\/\+^])/g, '\\$1') +
+        '=([^;]*)',
+    ),
+  );
+  return matches ? decodeURIComponent(matches[1]) : undefined;
+}
+
+function deleteCookie(name) {
+  document.cookie = name + '=; Max-Age=0';
+}
+
+module.exports = {
+  getCookie,
+  deleteCookie,
+};


### PR DESCRIPTION
> 토큰 쿠키로 유저 정보를 연동하고, 미로그인 시 로그인 페이지로 이동시킴

## related issue

- #79
- #23

## 설명 (what, why)
### 1. 액세스 토큰 정보 API
- cookie에 설정된 토큰 정보로 유저 정보를 반환함
### 2. 액세스 토큰 발급 API
- 쿠키 설정 부분에서 millisecond 가 아닌 second 단위로 설정돼있어,
쿠키가 매번 지워지던 버그 해결
### 3. 로그인 여부 확인
- 미로그인 시, 로그인 페이지로 이동
### 4. 엔트리 포인트에서 토큰 쿠키가 있으면, 유저 정보 API 요청
- 요청 여부를 저장해둠으로써, 칸반 페이지 로드 시, 매번 이동시키던 문제 해결
- 만약 토큰 오류 시, 메세지와 함께 로그인 페이지로 이동됨