### PR TITLE
PR: HOTFIX - import loginpage 파일 오타 수정

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -4,7 +4,7 @@ import Store from './javascripts/Store/Store.js';
 import { getCookie, deleteCookie } from './javascripts/Utils/cookie.js';
 import Router from './javascripts/Components/Router.js';
 import KanbanPage from './javascripts/Components/KanbanPage.js';
-import LoginPage from './javascripts/Components/Loginpage.js';
+import LoginPage from './javascripts/Components/LoginPage.js';
 import ErrorPage from './javascripts/Components/ErrorPage.js';
 
 // eslint-disable-next-line no-unused-vars


### PR DESCRIPTION
>  파일 명을 일치시키기 위해 Loginpage를 LoginPage로 수정함

## 설명 (what, why)

front 페이지의 entrypoint에서 LoginPage를 import 할 때, 대소문자에 오타 확인

local에서 작업할 때 제대로 동작하지만, 배포 페이지에서 제대로 동작하지 않는 오류를 발견

따라서 이를 수정함