### PR TITLE
PR: fix - 노트가 많은 경우 scroll

### DIFF
--- a/src/stylesheets/kanban.css
+++ b/src/stylesheets/kanban.css
@@ -66,6 +66,7 @@ body section {
   border-radius: 10px;
 
   background-color: #cccccc;
+  overflow-y: auto;
 }
 
 .kanban .column .head {
@@ -117,8 +118,6 @@ body section {
   list-style: none;
   padding: 0;
   margin: 0;
-
-  overflow-y: auto;
 }
 
 .kanban .column ul li {


### PR DESCRIPTION


> column에 카드가 많은 경우 스크롤 가능하도록

## related issue

- #3

## 설명 (what, why)

기존에 ul에 overflow 속성으로 스크롤을 제작하려 했으나, ul 태그에 입력
overflow 속성에 제대로 동작하지 않음

따라서 이를 column로 위치를 옮김
