### PR TITLE
PR: fix - 컬럼에 노트가 많을 경우 overflow 속성 변경

### DIFF
--- a/src/stylesheets/kanban.css
+++ b/src/stylesheets/kanban.css
@@ -66,7 +66,6 @@ body section {
   border-radius: 10px;
 
   background-color: #cccccc;
-  overflow-y: auto;
 }
 
 .kanban .column .head {
@@ -118,6 +117,9 @@ body section {
   list-style: none;
   padding: 0;
   margin: 0;
+
+  height: calc(100% - 40px);
+  overflow-y: auto;
 }
 
 .kanban .column ul li {
@@ -125,7 +127,6 @@ body section {
   user-select: none;
 
   width: inherit;
-  height: inherit;
 
   margin: 10px;
   padding: 5px;


### PR DESCRIPTION
> 컬럼에 노트가 많은 경우 ul 태그에 overflow 속성 추가

## related PR

- #85 

## 설명 (what, why)

column에 직접 overflow를 설정하는 경우, 웹의 가로사이즈가 작아졌을 때 컬럼의 width도 줄어드는 문제가 있어, ul에 이를 지정함

ul에 height를 넣고 overflow를 설정하도록 수정

li에 height:inherit 부분 삭제
